### PR TITLE
[all] support attributes

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -55,7 +55,7 @@ fn guarded_entry(ctx: Rc<Context>, matches: &ArgMatches, output: &output::Output
 }
 
 fn entry(matches: &ArgMatches, output: &output::Output) -> Result<()> {
-    let ctx = Rc::new(Context::new());
+    let ctx = Rc::new(Context::default());
 
     if let Err(e) = guarded_entry(Rc::clone(&ctx), matches, output) {
         output.handle_context(ctx.as_ref())?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -12,31 +12,32 @@ use reproto::output;
 use std::io;
 use std::rc::Rc;
 
-const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn setup_opts<'a, 'b>() -> App<'a, 'b> {
-    let app = App::new("reproto").version(VERSION);
-    let app = app.arg(Arg::with_name("debug").long("debug").short("D").help(
-        "Enable debug \
-         output",
-    ));
-    let app = app.arg(Arg::with_name("color").long("color").help(
-        "Force colored output",
-    ));
-    let app = app.arg(Arg::with_name("no-color").long("no-color").help(
-        "Disable colored \
-         output",
-    ));
-    app
+    App::new("reproto")
+        .version(VERSION)
+        .arg(Arg::with_name("debug").long("debug").short("D").help(
+            "Enable debug \
+             output",
+        ))
+        .arg(Arg::with_name("color").long("color").help(
+            "Force colored output",
+        ))
+        .arg(Arg::with_name("no-color").long("no-color").help(
+            "Disable colored \
+             output",
+        ))
 }
 
 /// Configure logging
 ///
-/// If debug (--debug) is specified, logging should be configured with LogLevelFilter::Debug.
+/// If debug (--debug) is specified, logging should be configured with `LogLevelFilter::Debug`.
 fn setup_logger(matches: &clap::ArgMatches, output: &output::Output) -> Result<()> {
-    let level: log::LogLevelFilter = match matches.is_present("debug") {
-        true => log::LogLevelFilter::Debug,
-        false => log::LogLevelFilter::Info,
+    let level = if matches.is_present("debug") {
+        log::LogLevelFilter::Debug
+    } else {
+        log::LogLevelFilter::Info
     };
 
     log::set_logger(|max_level| {
@@ -47,16 +48,16 @@ fn setup_logger(matches: &clap::ArgMatches, output: &output::Output) -> Result<(
     Ok(())
 }
 
-fn guarded_entry(ctx: Rc<Context>, matches: ArgMatches, output: &output::Output) -> Result<()> {
-    setup_logger(&matches, output)?;
-    ops::entry(ctx, &matches)?;
+fn guarded_entry(ctx: Rc<Context>, matches: &ArgMatches, output: &output::Output) -> Result<()> {
+    setup_logger(matches, output)?;
+    ops::entry(ctx, matches)?;
     Ok(())
 }
 
-fn entry(matches: ArgMatches, output: &output::Output) -> Result<()> {
+fn entry(matches: &ArgMatches, output: &output::Output) -> Result<()> {
     let ctx = Rc::new(Context::new());
 
-    if let Err(e) = guarded_entry(ctx.clone(), matches, output) {
+    if let Err(e) = guarded_entry(Rc::clone(&ctx), matches, output) {
         output.handle_context(ctx.as_ref())?;
 
         if !output.handle_error(&e)? {
@@ -83,7 +84,7 @@ fn main() {
         Box::new(output::NonColored::new(io::stdout()))
     };
 
-    if let Err(e) = entry(matches, output.as_mut()) {
+    if let Err(e) = entry(&matches, output.as_mut()) {
         output.print_root_error(&e).unwrap();
         ::std::process::exit(1);
     }

--- a/examples/src/io/reproto/blog.reproto
+++ b/examples/src/io/reproto/blog.reproto
@@ -79,5 +79,5 @@ service Blob {
   get_posts() -> stream PostEntry as "GetPosts";
 
   /// Get the post with the given `id`.
-  get_post(string) -> Post;
+  get_post(request: string) -> Post;
 }

--- a/examples/src/io/reproto/toystore.reproto
+++ b/examples/src/io/reproto/toystore.reproto
@@ -72,13 +72,13 @@ service ToyStore {
   ///
   /// The stream will contain all the toys in the store, it is up to the client to terminate when
   /// done.
-  get_toys(::GetToys) -> stream Toy;
+  get_toys(request: ::GetToys) -> stream Toy;
 
   /// Get a single toy by its identifier.
-  get_toy(u64) -> Toy;
+  get_toy(request: u64) -> Toy;
 
   /// Gets a greeting for the given `name`.
-  get_greeting(string) -> c::Greeting;
+  get_greeting(request: string) -> c::Greeting;
 
   /// The get_toys request body.
   ///

--- a/it/test-interfaces/expected/project/java/one.json
+++ b/it/test-interfaces/expected/project/java/one.json
@@ -1,4 +1,8 @@
-Foo()
+A()
 {"type":"foo"}
+B()
+{"type":"b"}
 Bar()
-{"type":"bar"}
+{"type":"Bar"}
+Baz()
+{"type":"Baz"}

--- a/it/test-interfaces/expected/project/js/one.json
+++ b/it/test-interfaces/expected/project/js/one.json
@@ -1,4 +1,8 @@
-Entry_Foo {}
-{"type":"Entry_Foo"}
+Entry_A {}
+{"type":"Entry_Baz"}
+Entry_B {}
+{"type":"Entry_Baz"}
 Entry_Bar {}
-{"type":"Entry_Foo"}
+{"type":"Entry_Baz"}
+Entry_Baz {}
+{"type":"Entry_Baz"}

--- a/it/test-interfaces/expected/project/python/one.json
+++ b/it/test-interfaces/expected/project/python/one.json
@@ -1,4 +1,8 @@
-<Entry_Foo >
+<Entry_A >
 {"type": "foo"}
+<Entry_B >
+{"type": "b"}
 <Entry_Bar >
-{"type": "bar"}
+{"type": "Bar"}
+<Entry_Baz >
+{"type": "Baz"}

--- a/it/test-interfaces/expected/project/python3/one.json
+++ b/it/test-interfaces/expected/project/python3/one.json
@@ -1,4 +1,8 @@
-<Entry_Foo >
+<Entry_A >
 {"type": "foo"}
+<Entry_B >
+{"type": "b"}
 <Entry_Bar >
-{"type": "bar"}
+{"type": "Bar"}
+<Entry_Baz >
+{"type": "Baz"}

--- a/it/test-interfaces/expected/project/rust/one.json
+++ b/it/test-interfaces/expected/project/rust/one.json
@@ -1,4 +1,8 @@
-Foo
+A
 {"type":"foo"}
+B
+{"type":"b"}
 Bar
-{"type":"bar"}
+{"type":"Bar"}
+Baz
+{"type":"Baz"}

--- a/it/test-interfaces/expected/suite/java/test/Entry.java
+++ b/it/test-interfaces/expected/suite/java/test/Entry.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonSubTypes({
   @JsonSubTypes.Type(name="foo", value=Entry.A.class),
   @JsonSubTypes.Type(name="b", value=Entry.B.class),
-  @JsonSubTypes.Type(name="B", value=Entry.B.class),
   @JsonSubTypes.Type(name="Bar", value=Entry.Bar.class),
   @JsonSubTypes.Type(name="Baz", value=Entry.Baz.class)
 })

--- a/it/test-interfaces/expected/suite/js/test.js
+++ b/it/test-interfaces/expected/suite/js/test.js
@@ -11,10 +11,6 @@ export class Entry {
       return Entry_B.decode(data);
     }
 
-    if (f_type === "B") {
-      return Entry_B.decode(data);
-    }
-
     if (f_type === "Bar") {
       return Entry_Bar.decode(data);
     }

--- a/it/test-interfaces/expected/suite/python/test.py
+++ b/it/test-interfaces/expected/suite/python/test.py
@@ -9,9 +9,6 @@ class Entry:
     if f_type == "b":
       return Entry_B.decode(data)
 
-    if f_type == "B":
-      return Entry_B.decode(data)
-
     if f_type == "Bar":
       return Entry_Bar.decode(data)
 

--- a/it/test-interfaces/expected/suite/python3/test.py
+++ b/it/test-interfaces/expected/suite/python3/test.py
@@ -9,9 +9,6 @@ class Entry:
     if f_type == "b":
       return Entry_B.decode(data)
 
-    if f_type == "B":
-      return Entry_B.decode(data)
-
     if f_type == "Bar":
       return Entry_Bar.decode(data)
 

--- a/it/test-interfaces/input/one.json
+++ b/it/test-interfaces/input/one.json
@@ -1,3 +1,4 @@
 {"type": "foo"}
+{"type": "b"}
 {"type": "Bar"}
 {"type": "Baz"}

--- a/it/test-interfaces/proto/test.reproto
+++ b/it/test-interfaces/proto/test.reproto
@@ -1,7 +1,7 @@
 interface Entry {
   A as "foo";
 
-  B as ["b", "B"];
+  B as "b";
 
   Bar {
   }

--- a/it/test-java-okhttp1/Makefile
+++ b/it/test-java-okhttp1/Makefile
@@ -1,0 +1,1 @@
+suites := java

--- a/it/test-java-okhttp1/expected/suite/java/io/reproto/client/ApiClient.java
+++ b/it/test-java-okhttp1/expected/suite/java/io/reproto/client/ApiClient.java
@@ -1,0 +1,4 @@
+package io.reproto.client;
+
+public class ApiClient {
+}

--- a/it/test-java-okhttp1/expected/suite/java/test/Entry.java
+++ b/it/test-java-okhttp1/expected/suite/java/test/Entry.java
@@ -1,0 +1,47 @@
+package test;
+
+
+public class Entry {
+  public Entry() {
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 1;
+    return result;
+  }
+
+  @Override
+  public boolean equals(final Object other) {
+    if (other == null) {
+      return false;
+    }
+
+    if (!(other instanceof Entry)) {
+      return false;
+    }
+
+    @SuppressWarnings("unchecked")
+    final Entry o = (Entry) other;
+
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder b = new StringBuilder();
+
+    b.append("Entry");
+    b.append("(");
+    b.append(")");
+
+    return b.toString();
+  }
+
+  public static class Builder {
+    public Entry build() {
+
+      return new Entry();
+    }
+  }
+}

--- a/it/test-java-okhttp1/expected/suite/java/test/MyService.java
+++ b/it/test-java-okhttp1/expected/suite/java/test/MyService.java
@@ -1,0 +1,19 @@
+package test;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface MyService {
+  CompletableFuture<Void> unknown();
+
+  CompletableFuture<Entry> unknownReturn();
+
+  CompletableFuture<Void> unknownArgument(final Entry request);
+
+  CompletableFuture<Entry> unary(final Entry request);
+
+  CompletableFuture<Entry> serverStreaming(final Entry request);
+
+  CompletableFuture<Entry> clientStreaming(final Entry request);
+
+  CompletableFuture<Entry> bidiStreaming(final Entry request);
+}

--- a/it/test-java-okhttp1/input/one.json
+++ b/it/test-java-okhttp1/input/one.json
@@ -1,0 +1,3 @@
+{"thing":{"name":"The Thing"}}
+{"thing":{"other":{"name":"The Other Thing"}}}
+{"thing":{"other2":{"name2":"The Other-Other Thing"}}}

--- a/it/test-java-okhttp1/proto/test.reproto
+++ b/it/test-java-okhttp1/proto/test.reproto
@@ -1,0 +1,25 @@
+type Entry {
+}
+
+service MyService {
+    /// UNKNOWN
+    unknown();
+
+    /// UNKNOWN
+    unknown_return() -> Entry;
+
+    /// UNKNOWN
+    unknown_argument(request: Entry);
+
+    /// UNARY
+    unary(request: Entry) -> Entry;
+
+    /// SERVER_STREMAING
+    server_streaming(request: Entry) -> stream Entry;
+
+    /// CLIENT_STREAMING
+    client_streaming(request: stream Entry) -> Entry;
+
+    /// BIDI_STREAMING
+    bidi_streaming(request: stream Entry) -> stream Entry;
+}

--- a/it/test-java-okhttp1/reproto.toml
+++ b/it/test-java-okhttp1/reproto.toml
@@ -1,0 +1,2 @@
+[modules.okhttp]
+version = "1"

--- a/it/test-java-okhttp2/Makefile
+++ b/it/test-java-okhttp2/Makefile
@@ -1,0 +1,1 @@
+suites := java

--- a/it/test-java-okhttp2/expected/suite/java/io/reproto/client/ApiClient.java
+++ b/it/test-java-okhttp2/expected/suite/java/io/reproto/client/ApiClient.java
@@ -1,0 +1,4 @@
+package io.reproto.client;
+
+public class ApiClient {
+}

--- a/it/test-java-okhttp2/expected/suite/java/test/Entry.java
+++ b/it/test-java-okhttp2/expected/suite/java/test/Entry.java
@@ -1,0 +1,47 @@
+package test;
+
+
+public class Entry {
+  public Entry() {
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 1;
+    return result;
+  }
+
+  @Override
+  public boolean equals(final Object other) {
+    if (other == null) {
+      return false;
+    }
+
+    if (!(other instanceof Entry)) {
+      return false;
+    }
+
+    @SuppressWarnings("unchecked")
+    final Entry o = (Entry) other;
+
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder b = new StringBuilder();
+
+    b.append("Entry");
+    b.append("(");
+    b.append(")");
+
+    return b.toString();
+  }
+
+  public static class Builder {
+    public Entry build() {
+
+      return new Entry();
+    }
+  }
+}

--- a/it/test-java-okhttp2/expected/suite/java/test/MyService.java
+++ b/it/test-java-okhttp2/expected/suite/java/test/MyService.java
@@ -1,0 +1,19 @@
+package test;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface MyService {
+  CompletableFuture<Void> unknown();
+
+  CompletableFuture<Entry> unknownReturn();
+
+  CompletableFuture<Void> unknownArgument(final Entry request);
+
+  CompletableFuture<Entry> unary(final Entry request);
+
+  CompletableFuture<Entry> serverStreaming(final Entry request);
+
+  CompletableFuture<Entry> clientStreaming(final Entry request);
+
+  CompletableFuture<Entry> bidiStreaming(final Entry request);
+}

--- a/it/test-java-okhttp2/input/one.json
+++ b/it/test-java-okhttp2/input/one.json
@@ -1,0 +1,3 @@
+{"thing":{"name":"The Thing"}}
+{"thing":{"other":{"name":"The Other Thing"}}}
+{"thing":{"other2":{"name2":"The Other-Other Thing"}}}

--- a/it/test-java-okhttp2/proto/test.reproto
+++ b/it/test-java-okhttp2/proto/test.reproto
@@ -1,0 +1,25 @@
+type Entry {
+}
+
+service MyService {
+    /// UNKNOWN
+    unknown();
+
+    /// UNKNOWN
+    unknown_return() -> Entry;
+
+    /// UNKNOWN
+    unknown_argument(request: Entry);
+
+    /// UNARY
+    unary(request: Entry) -> Entry;
+
+    /// SERVER_STREMAING
+    server_streaming(request: Entry) -> stream Entry;
+
+    /// CLIENT_STREAMING
+    client_streaming(request: stream Entry) -> Entry;
+
+    /// BIDI_STREAMING
+    bidi_streaming(request: stream Entry) -> stream Entry;
+}

--- a/it/test-java-okhttp2/reproto.toml
+++ b/it/test-java-okhttp2/reproto.toml
@@ -1,0 +1,2 @@
+[modules.okhttp]
+version = "2"

--- a/it/test-service/expected/suite/doc/service/service.MyService.html
+++ b/it/test-service/expected/suite/doc/service/service.MyService.html
@@ -55,6 +55,8 @@
           <span class="endpoint-id">unknown_argument</span>
           <span>(</span>
           <span class="endpoint-request-type">
+            <span class="name">request</span>
+            <span class="sep">:</span>
             <span class="ty"><span class="type-rp-name">
               <a class="name-package" href="../common/1.0.0/index.html">c</a>
               <span class="name-sep">::</span>
@@ -74,6 +76,8 @@
           <span class="endpoint-id">unary</span>
           <span>(</span>
           <span class="endpoint-request-type">
+            <span class="name">request</span>
+            <span class="sep">:</span>
             <span class="ty"><span class="type-rp-name">
               <a class="name-package" href="../common/1.0.0/index.html">c</a>
               <span class="name-sep">::</span>
@@ -102,6 +106,8 @@
           <span class="endpoint-id">server_streaming</span>
           <span>(</span>
           <span class="endpoint-request-type">
+            <span class="name">request</span>
+            <span class="sep">:</span>
             <span class="ty"><span class="type-rp-name">
               <a class="name-package" href="../common/1.0.0/index.html">c</a>
               <span class="name-sep">::</span>
@@ -131,6 +137,8 @@
           <span class="endpoint-id">client_streaming</span>
           <span>(</span>
           <span class="endpoint-request-type">
+            <span class="name">request</span>
+            <span class="sep">:</span>
             <span class="keyword">stream</span>
             <span class="ty"><span class="type-rp-name">
               <a class="name-package" href="../common/1.0.0/index.html">c</a>
@@ -160,6 +168,8 @@
           <span class="endpoint-id">bidi_streaming</span>
           <span>(</span>
           <span class="endpoint-request-type">
+            <span class="name">request</span>
+            <span class="sep">:</span>
             <span class="keyword">stream</span>
             <span class="ty"><span class="type-rp-name">
               <a class="name-package" href="../common/1.0.0/index.html">c</a>

--- a/it/test-service/proto/service.reproto
+++ b/it/test-service/proto/service.reproto
@@ -8,17 +8,17 @@ service MyService {
     unknown_return() -> c::Entry;
 
     /// UNKNOWN
-    unknown_argument(c::Entry);
+    unknown_argument(request: c::Entry);
 
     /// UNARY
-    unary(c::Entry) -> c::Entry;
+    unary(request: c::Entry) -> c::Entry;
 
     /// SERVER_STREMAING
-    server_streaming(c::Entry) -> stream c::Entry;
+    server_streaming(request: c::Entry) -> stream c::Entry;
 
     /// CLIENT_STREAMING
-    client_streaming(stream c::Entry) -> c::Entry;
+    client_streaming(request: stream c::Entry) -> c::Entry;
 
     /// BIDI_STREAMING
-    bidi_streaming(stream c::Entry) -> stream c::Entry;
+    bidi_streaming(request: stream c::Entry) -> stream c::Entry;
 }

--- a/lib/ast/lib.rs
+++ b/lib/ast/lib.rs
@@ -16,6 +16,10 @@ pub enum AttributeItem<'input> {
         name: Loc<&'input str>,
         value: Loc<Value<'input>>,
     },
+    NameType {
+        name: Loc<&'input str>,
+        ty: Loc<Type>,
+    },
 }
 
 /// An attribute.
@@ -268,7 +272,7 @@ pub enum ServiceMember<'input> {
 /// ```ignore
 /// /// <comment>
 /// #[attribute]
-/// <id>(<request>) -> <response> as <alias> {
+/// <id>(<arguments>) -> <response> as <alias> {
 ///   <options>
 /// }
 /// ```
@@ -280,7 +284,7 @@ pub struct Endpoint<'input> {
     pub attributes: Vec<Loc<Attribute<'input>>>,
     pub alias: Option<String>,
     pub options: Vec<Loc<OptionDecl<'input>>>,
-    pub request: Option<Loc<Channel>>,
+    pub arguments: Vec<(Loc<&'input str>, Loc<Channel>)>,
     pub response: Option<Loc<Channel>>,
 }
 

--- a/lib/ast/lib.rs
+++ b/lib/ast/lib.rs
@@ -138,13 +138,21 @@ pub struct EnumBody<'input> {
     pub name: &'input str,
     pub ty: Option<Loc<Type>>,
     pub variants: Vec<Item<'input, EnumVariant<'input>>>,
-    pub members: Vec<Member<'input>>,
+    pub members: Vec<EnumMember<'input>>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct EnumVariant<'input> {
     pub name: Loc<&'input str>,
     pub argument: Option<Loc<Value<'input>>>,
+}
+
+/// A member in a tuple, type, or interface.
+#[derive(Debug, PartialEq, Eq)]
+pub enum EnumMember<'input> {
+    Code(Loc<Code<'input>>),
+    Option(Loc<OptionDecl<'input>>),
+    InnerDecl(Decl<'input>),
 }
 
 /// A field.
@@ -221,7 +229,7 @@ pub enum Name {
 #[derive(Debug, PartialEq, Eq)]
 pub struct InterfaceBody<'input> {
     pub name: &'input str,
-    pub members: Vec<Member<'input>>,
+    pub members: Vec<TypeMember<'input>>,
     pub sub_types: Vec<Item<'input, SubType<'input>>>,
 }
 
@@ -234,7 +242,7 @@ pub struct Code<'input> {
 
 /// A member in a tuple, type, or interface.
 #[derive(Debug, PartialEq, Eq)]
-pub enum Member<'input> {
+pub enum TypeMember<'input> {
     Field(Item<'input, Field<'input>>),
     Code(Loc<Code<'input>>),
     Option(Loc<OptionDecl<'input>>),
@@ -341,7 +349,7 @@ pub enum Channel {
 #[derive(Debug, PartialEq, Eq)]
 pub struct SubType<'input> {
     pub name: Loc<&'input str>,
-    pub members: Vec<Member<'input>>,
+    pub members: Vec<TypeMember<'input>>,
     pub alias: Option<Loc<Value<'input>>>,
 }
 
@@ -355,7 +363,7 @@ pub struct SubType<'input> {
 #[derive(Debug, PartialEq, Eq)]
 pub struct TupleBody<'input> {
     pub name: &'input str,
-    pub members: Vec<Member<'input>>,
+    pub members: Vec<TypeMember<'input>>,
 }
 
 /// The body of a type
@@ -368,7 +376,7 @@ pub struct TupleBody<'input> {
 #[derive(Debug, PartialEq, Eq)]
 pub struct TypeBody<'input> {
     pub name: &'input str,
-    pub members: Vec<Member<'input>>,
+    pub members: Vec<TypeMember<'input>>,
 }
 
 /// A use declaration

--- a/lib/ast/lib.rs
+++ b/lib/ast/lib.rs
@@ -2,6 +2,41 @@ extern crate reproto_core;
 
 use reproto_core::{Loc, OptionEntry, RpModifier, RpNumber, RpPackage};
 
+/// Name value pair.
+///
+/// Is associated with attributes:
+///
+/// ```ignore
+/// #[attribute(name = <value>)]
+/// ```
+#[derive(Debug, PartialEq, Eq)]
+pub enum AttributeItem<'input> {
+    Word(Loc<&'input str>),
+    NameValue {
+        name: Loc<&'input str>,
+        value: Loc<Value<'input>>,
+    },
+}
+
+/// An attribute.
+///
+/// Attributes are metadata associated with elements.
+///
+/// ```ignore
+/// #[word]
+/// ```
+///
+/// or:
+///
+/// ```ignore
+/// #[name_value(foo = <value>, bar = <value>)]
+/// ```
+#[derive(Debug, PartialEq, Eq)]
+pub enum Attribute<'input> {
+    Word(Loc<&'input str>),
+    List(Loc<&'input str>, Vec<AttributeItem<'input>>),
+}
+
 /// A type.
 ///
 /// For example: `u32`, `::Relative::Name`, or `bytes`.
@@ -232,6 +267,7 @@ pub enum ServiceMember<'input> {
 ///
 /// ```ignore
 /// /// <comment>
+/// #[attribute]
 /// <id>(<request>) -> <response> as <alias> {
 ///   <options>
 /// }
@@ -240,6 +276,8 @@ pub enum ServiceMember<'input> {
 pub struct Endpoint<'input> {
     pub id: Loc<&'input str>,
     pub comment: Vec<&'input str>,
+    /// Attributes associated with the endpoint.
+    pub attributes: Vec<Loc<Attribute<'input>>>,
     pub alias: Option<String>,
     pub options: Vec<Loc<OptionDecl<'input>>>,
     pub request: Option<Loc<Channel>>,

--- a/lib/ast/lib.rs
+++ b/lib/ast/lib.rs
@@ -16,10 +16,6 @@ pub enum AttributeItem<'input> {
         name: Loc<&'input str>,
         value: Loc<Value<'input>>,
     },
-    NameType {
-        name: Loc<&'input str>,
-        ty: Loc<Type>,
-    },
 }
 
 /// An attribute.
@@ -371,4 +367,5 @@ pub enum Value<'input> {
     Boolean(bool),
     Identifier(&'input str),
     Array(Vec<Loc<Value<'input>>>),
+    Type(Type),
 }

--- a/lib/backend-doc/src/doc_compiler.rs
+++ b/lib/backend-doc/src/doc_compiler.rs
@@ -3,7 +3,7 @@
 use super::{DOC_CSS_NAME, NORMALIZE_CSS_NAME};
 use backend::Environment;
 use backend::errors::*;
-use core::{ForEachLoc, RpDecl, RpFile, RpVersionedPackage};
+use core::{WithPos, RpDecl, RpFile, RpVersionedPackage};
 use doc_builder::DocBuilder;
 use enum_processor::EnumProcessor;
 use genco::IoFmt;
@@ -37,9 +37,9 @@ impl<'a> DocCompiler<'a> {
     /// Do the compilation.
     pub fn compile(&self) -> Result<()> {
         for (_, file) in self.env.for_each_file() {
-            file.for_each_decl().for_each_loc(
-                |decl| self.process_decl(decl),
-            )?;
+            for decl in file.for_each_decl() {
+                self.process_decl(decl).with_pos(decl.pos())?;
+            }
         }
 
         self.write_index(self.env.for_each_file())?;

--- a/lib/backend-doc/src/package_processor.rs
+++ b/lib/backend-doc/src/package_processor.rs
@@ -49,7 +49,7 @@ define_processor!(PackageProcessor, Data<'env>, self,
             let mut services = Vec::new();
 
             for decl in self.body.file.for_each_decl() {
-                match *decl.value() {
+                match *decl {
                     Type(ref ty) => types.push(ty),
                     Interface(ref interface) => interfaces.push(interface),
                     Enum(ref en) => enums.push(en),

--- a/lib/backend-doc/src/processor.rs
+++ b/lib/backend-doc/src/processor.rs
@@ -3,13 +3,12 @@
 use super::{DOC_CSS_NAME, NORMALIZE_CSS_NAME};
 use backend::Environment;
 use backend::errors::*;
-use core::{ForEachLoc, Loc, RpDecl, RpField, RpName, RpType, RpVersionedPackage};
+use core::{WithPos, ForEachLoc, Loc, RpDecl, RpField, RpName, RpType, RpVersionedPackage};
 use doc_builder::DocBuilder;
 use escape::Escape;
 use macros::FormatAttribute;
 use rendering::markdown_to_html;
 use std::ops::DerefMut;
-use std::rc::Rc;
 use syntect::highlighting::Theme;
 use syntect::parsing::SyntaxSet;
 
@@ -205,9 +204,12 @@ pub trait Processor<'env> {
     /// Render a set of nested declarations
     fn nested_decls<'b, I>(&self, decls: I) -> Result<()>
     where
-        I: Iterator<Item = &'b Rc<Loc<RpDecl>>>,
+        I: Iterator<Item = &'b RpDecl>,
     {
-        decls.for_each_loc(|decl| self.nested_decl(decl))?;
+        for decl in decls {
+            self.nested_decl(decl).with_pos(decl.pos())?;
+        }
+
         Ok(())
     }
 

--- a/lib/backend-doc/src/service_processor.rs
+++ b/lib/backend-doc/src/service_processor.rs
@@ -46,13 +46,18 @@ impl<'p> ServiceProcessor<'p> {
             html!(self, span {class => "endpoint-id"} ~ Escape(endpoint.id.as_str()));
             html!(self, span {} ~ Escape("("));
 
-            if let Some(request) = endpoint.request.as_ref().take().as_ref() {
+            let mut it = endpoint.arguments.iter().peekable();
+
+            while let Some((name, channel)) = it.next() {
                 html!(self, span {class => "endpoint-request-type"} => {
-                    if request.is_streaming() {
+                    html!(self, span {class => "name"} ~ Escape(name.as_str()));
+                    html!(self, span {class => "sep"} ~ Escape(":"));
+
+                    if channel.is_streaming() {
                         html!(self, span {class => "keyword"} ~ Escape("stream"));
                     }
 
-                    let (req, pos) = request.as_ref_pair();
+                    let (req, pos) = channel.as_ref_pair();
                     self.write_type(req.ty()).with_pos(pos)?;
                 });
             }

--- a/lib/backend-java/src/codegen.rs
+++ b/lib/backend-java/src/codegen.rs
@@ -1,0 +1,9 @@
+/// Code generator for the given path.
+
+use backend::errors::Result;
+use std::path::Path;
+
+pub trait Codegen {
+    /// Build the given piece of code in the given path.
+    fn generate(&self, out_path: &Path) -> Result<()>;
+}

--- a/lib/backend-java/src/jackson.rs
+++ b/lib/backend-java/src/jackson.rs
@@ -446,23 +446,19 @@ impl Listeners for Module {
             let mut args = Tokens::new();
 
             for (key, sub_type) in &e.body.sub_types {
-                for name in &sub_type.names {
-                    let name = name.value().to_owned();
+                let mut a = Tokens::new();
 
-                    let mut a = Tokens::new();
+                a.append(toks!["name=", sub_type.name().quoted()]);
+                a.append(toks![
+                    "value=",
+                    e.spec.name(),
+                    ".",
+                    key.as_str(),
+                    ".class",
+                ]);
 
-                    a.append(toks!["name=", name.quoted()]);
-                    a.append(toks![
-                        "value=",
-                        e.spec.name(),
-                        ".",
-                        key.as_str(),
-                        ".class",
-                    ]);
-
-                    let arg = SubTypesType(self, a).into_tokens();
-                    args.append(arg);
-                }
+                let arg = SubTypesType(self, a).into_tokens();
+                args.append(arg);
             }
 
             e.spec.annotation(SubTypes(self, args));

--- a/lib/backend-java/src/java_file.rs
+++ b/lib/backend-java/src/java_file.rs
@@ -1,0 +1,55 @@
+//! Helper component to build Java files.
+
+use backend::errors::*;
+use genco::{IoFmt, Java, Tokens, WriteTokens};
+use genco::java::Extra;
+use std::fs::{self, File};
+use std::path::Path;
+
+pub struct JavaFile<'el, F> {
+    package: &'el str,
+    class_name: &'el str,
+    builder: F,
+}
+
+impl<'el, F> JavaFile<'el, F>
+where
+    F: FnOnce(&mut Tokens<'el, Java<'el>>) -> Result<()>,
+{
+    pub fn new(package: &'el str, class_name: &'el str, builder: F) -> JavaFile<'el, F> {
+        JavaFile {
+            package: package,
+            class_name: class_name,
+            builder: builder,
+        }
+    }
+
+    pub fn process(self, out_path: &Path) -> Result<()> {
+        let parts = self.package.split('.').collect::<Vec<_>>();
+
+        let client_path = parts.iter().cloned().fold(out_path.to_owned(), |p, part| {
+            p.join(part)
+        });
+
+        if !client_path.is_dir() {
+            debug!("+dir: {}", client_path.display());
+            fs::create_dir_all(&client_path)?;
+        }
+
+        let client_path = client_path.join(format!("{}.java", self.class_name));
+
+        let mut file: Tokens<Java> = Tokens::new();
+        (self.builder)(&mut file)?;
+
+        let mut extra = Extra::default();
+        extra.package(self.package);
+
+        debug!("+class: {}", client_path.display());
+        IoFmt(&mut File::create(client_path)?).write_file(
+            file,
+            &mut extra,
+        )?;
+
+        Ok(())
+    }
+}

--- a/lib/backend-java/src/java_options.rs
+++ b/lib/backend-java/src/java_options.rs
@@ -1,4 +1,7 @@
+/// Options for java code generation.
+
 use genco::Java;
+use codegen::Codegen;
 
 pub struct JavaOptions {
     /// Should fields be nullable?
@@ -21,6 +24,8 @@ pub struct JavaOptions {
     pub async_container: Option<Java<'static>>,
     /// Do not generate methods in service interface.
     pub suppress_service_methods: bool,
+    /// Hook to generate code called in the root of the declarations.
+    pub root_generators: Vec<Box<Codegen>>,
 }
 
 impl JavaOptions {
@@ -36,6 +41,7 @@ impl JavaOptions {
             build_to_string: true,
             async_container: None,
             suppress_service_methods: false,
+            root_generators: Vec::new(),
         }
     }
 }

--- a/lib/backend-java/src/module/mod.rs
+++ b/lib/backend-java/src/module/mod.rs
@@ -1,0 +1,3 @@
+mod okhttp;
+
+pub use self::okhttp::{Module as OkHttp, Config as OkHttpConfig};

--- a/lib/backend-java/src/module/okhttp.rs
+++ b/lib/backend-java/src/module/okhttp.rs
@@ -1,0 +1,69 @@
+//! Module that adds fasterxml annotations to generated classes.
+
+use backend::errors::*;
+use codegen::Codegen;
+use genco::{Java, Tokens};
+use java_file::JavaFile;
+use java_options::JavaOptions;
+use listeners::Listeners;
+use std::path::Path;
+
+#[derive(Debug, Deserialize)]
+pub enum Version {
+    #[serde(rename = "1")]
+    Version1,
+    #[serde(rename = "2")]
+    Version2,
+}
+
+impl Default for Version {
+    fn default() -> Self {
+        Version::Version1
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct Config {
+    version: Version,
+}
+
+pub struct Module {
+    #[allow(dead_code)]
+    config: Config,
+}
+
+impl Module {
+    pub fn new(config: Config) -> Module {
+        Module { config: config }
+    }
+}
+
+pub struct ApiClient {}
+
+impl ApiClient {
+    fn process<'el>(&self, container: &mut Tokens<'el, Java<'el>>) -> Result<()> {
+        container.push("public class ApiClient {");
+        container.push("}");
+        Ok(())
+    }
+}
+
+impl Codegen for ApiClient {
+    fn generate(&self, out_path: &Path) -> Result<()> {
+        JavaFile::new("io.reproto.client", "ApiClient", |out| self.process(out)).process(out_path)
+    }
+}
+
+/// Build an api client.
+impl ApiClient {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Listeners for Module {
+    fn configure(&self, options: &mut JavaOptions) -> Result<()> {
+        options.root_generators.push(Box::new(ApiClient::new()));
+        Ok(())
+    }
+}

--- a/lib/backend-js/src/js_backend.rs
+++ b/lib/backend-js/src/js_backend.rs
@@ -713,11 +713,11 @@ impl<'el> DynamicDecode<'el> for JsBackend {
         &self,
         data: &'el str,
         type_var: &'el str,
-        name: &'el Loc<String>,
+        name: &'el str,
         type_name: Tokens<'el, Self::Custom>,
     ) -> Tokens<'el, JavaScript<'el>> {
         let mut body = Tokens::new();
-        let cond = toks![type_var, " === ", name.as_str().quoted()];
+        let cond = toks![type_var, " === ", name.quoted()];
         body.push(js![if cond, js![return type_name, ".decode(", data, ")"]]);
         body
     }

--- a/lib/backend-python/src/python_backend.rs
+++ b/lib/backend-python/src/python_backend.rs
@@ -746,7 +746,7 @@ impl<'el> DynamicDecode<'el> for PythonBackend {
         &self,
         _data: &'el str,
         type_var: &'el str,
-        name: &'el Loc<String>,
+        name: &'el str,
         type_name: Tokens<'el, Self::Custom>,
     ) -> Tokens<'el, Self::Custom> {
         let mut check = Tokens::new();
@@ -755,7 +755,7 @@ impl<'el> DynamicDecode<'el> for PythonBackend {
             "if ",
             type_var,
             " == ",
-            name.value().as_str().quoted(),
+            name.quoted(),
             ":",
         ]);
 

--- a/lib/backend-rust/src/rust_backend.rs
+++ b/lib/backend-rust/src/rust_backend.rs
@@ -355,10 +355,8 @@ impl RustBackend {
             let mut spec = Tokens::new();
 
             // TODO: clone should not be needed
-            if let Some(ref sub_type_name) = s.names.first() {
-                let name = sub_type_name.as_str();
-
-                if name != s.local_name.as_str() {
+            if let Some(ref name) = s.sub_type_name {
+                if name.as_str() != s.local_name.as_str() {
                     spec.push(Rename(name));
                 }
             }

--- a/lib/backend/src/dynamic_decode.rs
+++ b/lib/backend/src/dynamic_decode.rs
@@ -2,7 +2,7 @@
 
 use base_decode::BaseDecode;
 use converter::Converter;
-use core::{Loc, RpInterfaceBody, RpType};
+use core::{RpInterfaceBody, RpType};
 use dynamic_converter::DynamicConverter;
 use errors::*;
 use genco::Tokens;
@@ -18,7 +18,7 @@ where
         &self,
         data: &'el str,
         type_var: &'el str,
-        name: &'el Loc<String>,
+        name: &'el str,
         type_name: Tokens<'el, Self::Custom>,
     ) -> Tokens<'el, Self::Custom>;
 
@@ -106,18 +106,16 @@ where
         decode_body.push(self.assign_type_var(data, type_var));
 
         for sub_type in body.sub_types.values() {
-            for sub_type_name in &sub_type.names {
-                let type_name = self.convert_type(&sub_type.name).map_err(|e| {
-                    ErrorKind::Pos(format!("{}", e), sub_type.pos().into())
-                })?;
+            let type_name = self.convert_type(&sub_type.name).map_err(|e| {
+                ErrorKind::Pos(format!("{}", e), sub_type.pos().into())
+            })?;
 
-                decode_body.push(self.check_type_var(
-                    data,
-                    type_var,
-                    sub_type_name,
-                    type_name,
-                ));
-            }
+            decode_body.push(self.check_type_var(
+                data,
+                type_var,
+                sub_type.name(),
+                type_name,
+            ));
         }
 
         decode_body.push(self.raise_bad_type(type_var));

--- a/lib/backend/src/environment.rs
+++ b/lib/backend/src/environment.rs
@@ -28,11 +28,11 @@ impl<'a> Iterator for ForEachFile<'a> {
 
 /// Iterator over all toplevel declarations.
 pub struct ToplevelDeclIter<'a> {
-    it: vec::IntoIter<&'a Rc<Loc<RpDecl>>>,
+    it: vec::IntoIter<&'a RpDecl>,
 }
 
 impl<'a> Iterator for ToplevelDeclIter<'a> {
-    type Item = &'a Rc<Loc<RpDecl>>;
+    type Item = &'a RpDecl;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.it.next()
@@ -41,11 +41,11 @@ impl<'a> Iterator for ToplevelDeclIter<'a> {
 
 /// Iterator over all declarations in a file.
 pub struct DeclIter<'a> {
-    queue: LinkedList<&'a Rc<Loc<RpDecl>>>,
+    queue: LinkedList<&'a RpDecl>,
 }
 
 impl<'a> Iterator for DeclIter<'a> {
-    type Item = &'a Rc<Loc<RpDecl>>;
+    type Item = &'a RpDecl;
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(decl) = self.queue.pop_front() {

--- a/lib/backend/src/environment.rs
+++ b/lib/backend/src/environment.rs
@@ -317,7 +317,7 @@ impl Environment {
             }
         };
 
-        for t in file.decls.iter().flat_map(|d| d.into_reg()) {
+        for t in file.decls.iter().flat_map(|d| d.to_reg()) {
             let key = t.name().clone().without_prefix();
 
             match self.types.entry(key) {

--- a/lib/backend/src/into_model.rs
+++ b/lib/backend/src/into_model.rs
@@ -699,6 +699,7 @@ impl<'input> IntoModel for Value<'input> {
             Boolean(boolean) => RpValue::Boolean(boolean),
             Identifier(identifier) => RpValue::Identifier(identifier.to_owned()),
             Array(inner) => RpValue::Array(inner.into_model(scope)?),
+            Type(ty) => RpValue::Type(ty.into_model(scope)?),
         };
 
         Ok(out)
@@ -758,13 +759,6 @@ impl<'input> IntoModel for Vec<Loc<Attribute<'input>>> {
                                         let name = name.into_model(scope)?.take();
                                         let value = value.into_model(scope)?;
                                         values.insert(name, value);
-                                    }
-                                    AttributeItem::NameType { name, .. } => {
-                                        return Err(
-                                            ctx.report()
-                                                .err(name.pos(), "attribute not supported")
-                                                .into(),
-                                        );
                                     }
                                 }
                             }

--- a/lib/backend/src/scope.rs
+++ b/lib/backend/src/scope.rs
@@ -146,7 +146,7 @@ mod tests {
 
     #[test]
     pub fn test_scope() {
-        let ctx = Rc::new(Context::new());
+        let ctx = Rc::new(Context::default());
         let package = RpVersionedPackage::new(RpPackage::empty(), None);
         let prefixes = HashMap::new();
         let s = Scope::new(ctx, None, package, prefixes, None, None);

--- a/lib/core/src/attributes.rs
+++ b/lib/core/src/attributes.rs
@@ -1,0 +1,101 @@
+//! Provide a collection of attributes and a convenient way for querying them.
+//!
+//! These structures are all map-like.
+
+use loc::Loc;
+use pos::Pos;
+use rp_value::RpValue;
+use std::borrow::Borrow;
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::vec;
+
+/// Iterator over unused positions.
+pub struct Unused<'a> {
+    iter: vec::IntoIter<&'a Pos>,
+}
+
+impl<'a> Iterator for Unused<'a> {
+    type Item = &'a Pos;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Selection {
+    /// Storing words and their locations.
+    words: HashMap<String, Pos>,
+    /// Storing values and their locations.
+    values: HashMap<String, Loc<RpValue>>,
+}
+
+impl Selection {
+    pub fn new(words: HashMap<String, Pos>, values: HashMap<String, Loc<RpValue>>) -> Selection {
+        Selection {
+            words: words,
+            values: values,
+        }
+    }
+
+    /// Take the given value, removing it in the process.
+    pub fn take<Q: ?Sized>(&mut self, key: &Q) -> Option<Loc<RpValue>>
+    where
+        String: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        self.values.remove(key)
+    }
+
+    /// Get an iterator over unused positions.
+    pub fn unused(&self) -> Unused {
+        let mut positions = Vec::new();
+        positions.extend(self.values.values().map(Loc::pos));
+        Unused { iter: positions.into_iter() }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Attributes {
+    words: HashMap<String, Pos>,
+    selections: HashMap<String, Loc<Selection>>,
+}
+
+impl Attributes {
+    pub fn new(
+        words: HashMap<String, Pos>,
+        selections: HashMap<String, Loc<Selection>>,
+    ) -> Attributes {
+        Attributes {
+            words: words,
+            selections: selections,
+        }
+    }
+
+    /// Take the given selection, removing it in the process.
+    pub fn take_word<Q: ?Sized>(&mut self, key: &Q) -> bool
+    where
+        String: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        self.words.remove(key).is_some()
+    }
+
+    /// Take the given selection, removing it in the process.
+    pub fn take_selection<Q: ?Sized>(&mut self, key: &Q) -> Option<Selection>
+    where
+        String: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        self.selections.remove(key).map(Loc::take)
+    }
+
+    /// Get an iterator over unused positions.
+    pub fn unused(&self) -> Unused {
+        let mut positions = Vec::new();
+        positions.extend(self.words.values());
+        positions.extend(self.selections.values().map(Loc::pos));
+        Unused { iter: positions.into_iter() }
+    }
+}

--- a/lib/core/src/attributes.rs
+++ b/lib/core/src/attributes.rs
@@ -51,6 +51,7 @@ impl Selection {
     /// Get an iterator over unused positions.
     pub fn unused(&self) -> Unused {
         let mut positions = Vec::new();
+        positions.extend(self.words.values());
         positions.extend(self.values.values().map(Loc::pos));
         Unused { iter: positions.into_iter() }
     }

--- a/lib/core/src/context.rs
+++ b/lib/core/src/context.rs
@@ -17,13 +17,14 @@ pub enum ContextItem {
     InfoPos(ErrorPos, String),
 }
 
+#[derive(Default)]
 pub struct Context {
     errors: RefCell<Vec<ContextItem>>,
 }
 
 /// A reporter that processes the given error for the context.
 ///
-/// Converting the reporter into an ErrorKind causes it to accumulate the errors to the `Context`.
+/// Converting the reporter into an `ErrorKind` causes it to accumulate the errors to the `Context`.
 pub struct Reporter<'a> {
     ctx: &'a Context,
     errors: Vec<ContextItem>,
@@ -61,10 +62,6 @@ impl<'a> From<Reporter<'a>> for Error {
 }
 
 impl Context {
-    pub fn new() -> Context {
-        Context { errors: RefCell::new(Vec::new()) }
-    }
-
     /// Build a handle that can be used in conjunction with Result#map_err.
     pub fn report(&self) -> Reporter {
         Reporter {

--- a/lib/core/src/context.rs
+++ b/lib/core/src/context.rs
@@ -93,7 +93,7 @@ mod tests {
         let pos: Pos = (Rc::new(object.clone_object()), 0usize, 0usize).into();
         let other_pos: Pos = (Rc::new(object.clone_object()), 0usize, 0usize).into();
 
-        let ctx = Context::new();
+        let ctx = Context::default();
 
         let result: result::Result<(), &str> = Err("nope");
 

--- a/lib/core/src/errors.rs
+++ b/lib/core/src/errors.rs
@@ -10,8 +10,8 @@ error_chain! {
 
     errors {
         Context {
-            description("context error")
-            display("context error")
+            description("error")
+            display("error")
         }
 
         Pos(message: String, pos: ErrorPos) {

--- a/lib/core/src/errors.rs
+++ b/lib/core/src/errors.rs
@@ -40,8 +40,8 @@ impl WithPos for Error {
     fn with_pos<E: Into<ErrorPos>>(self, pos: E) -> Self {
         use self::ErrorKind::*;
 
-        match self.kind() {
-            &Pos(..) => self,
+        match *self.kind() {
+            Pos(..) => self,
             _ => {
                 let message = format!("{}", &self);
                 self.chain_err(|| ErrorKind::Pos(message, pos.into()))

--- a/lib/core/src/lib.rs
+++ b/lib/core/src/lib.rs
@@ -53,8 +53,10 @@ mod rp_versioned_package;
 mod with_pos;
 mod rp_enum_ordinal;
 mod context;
+mod attributes;
 pub mod errors;
 
+pub use self::attributes::{Attributes, Selection};
 pub use self::context::{Context, ContextItem, Reporter};
 pub use self::error_pos::ErrorPos;
 pub use self::for_each_loc::ForEachLoc;

--- a/lib/core/src/lib.rs
+++ b/lib/core/src/lib.rs
@@ -1,4 +1,5 @@
 #![recursion_limit = "1000"]
+#![allow(unknown_lints)]
 
 #[macro_use]
 extern crate serde_derive;

--- a/lib/core/src/loc.rs
+++ b/lib/core/src/loc.rs
@@ -43,7 +43,7 @@ impl<T> Loc<T> {
         (self.inner, self.pos)
     }
 
-    pub fn as_ref_pair<'a>(&'a self) -> (&'a T, &'a Pos) {
+    pub fn as_ref_pair(&self) -> (&T, &Pos) {
         (&self.inner, &self.pos)
     }
 
@@ -61,11 +61,11 @@ impl<T> Loc<T> {
         op(self.inner).with_pos(&self.pos)
     }
 
-    pub fn loc_ref<'a>(&'a self) -> Loc<&'a T> {
+    pub fn loc_ref(&self) -> Loc<&T> {
         Loc::new(&self.inner, self.pos.clone())
     }
 
-    pub fn as_ref<'a>(&'a self) -> Loc<&'a T> {
+    pub fn as_ref(&self) -> Loc<&T> {
         self.loc_ref()
     }
 }

--- a/lib/core/src/macros.rs
+++ b/lib/core/src/macros.rs
@@ -6,7 +6,7 @@ macro_rules! decl_body {
             pub name: $crate::rp_name::RpName,
             pub local_name: String,
             pub comment: Vec<String>,
-            pub decls: Vec<::std::rc::Rc<$crate::loc::Loc<$crate::rp_decl::RpDecl>>>,
+            pub decls: Vec<$crate::rp_decl::RpDecl>,
             $($rest)*
         }
     };

--- a/lib/core/src/macros.rs
+++ b/lib/core/src/macros.rs
@@ -6,7 +6,6 @@ macro_rules! decl_body {
             pub name: $crate::rp_name::RpName,
             pub local_name: String,
             pub comment: Vec<String>,
-            pub attributes: $crate::attributes::Attributes,
             pub decls: Vec<$crate::rp_decl::RpDecl>,
             $($rest)*
         }

--- a/lib/core/src/macros.rs
+++ b/lib/core/src/macros.rs
@@ -6,6 +6,7 @@ macro_rules! decl_body {
             pub name: $crate::rp_name::RpName,
             pub local_name: String,
             pub comment: Vec<String>,
+            pub attributes: $crate::attributes::Attributes,
             pub decls: Vec<$crate::rp_decl::RpDecl>,
             $($rest)*
         }

--- a/lib/core/src/object.rs
+++ b/lib/core/src/object.rs
@@ -45,15 +45,15 @@ impl Object for BytesObject {
 
     fn clone_object(&self) -> Box<Object> {
         Box::new(BytesObject {
-            name: self.name.clone(),
-            bytes: self.bytes.clone(),
+            name: Arc::clone(&self.name),
+            bytes: Arc::clone(&self.bytes),
         })
     }
 
     fn with_name(&self, name: String) -> Box<Object> {
         Box::new(BytesObject {
             name: Arc::new(name),
-            bytes: self.bytes.clone(),
+            bytes: Arc::clone(&self.bytes),
         })
     }
 }
@@ -91,14 +91,14 @@ impl Object for PathObject {
     fn clone_object(&self) -> Box<Object> {
         Box::new(PathObject {
             name: self.name.clone(),
-            path: self.path.clone(),
+            path: Arc::clone(&self.path),
         })
     }
 
     fn with_name(&self, name: String) -> Box<Object> {
         Box::new(PathObject {
             name: Some(Arc::new(name)),
-            path: self.path.clone(),
+            path: Arc::clone(&self.path),
         })
     }
 }

--- a/lib/core/src/pos.rs
+++ b/lib/core/src/pos.rs
@@ -1,8 +1,9 @@
 use super::Object;
 use std::rc::Rc;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub struct Pos {
+    #[serde(skip)]
     pub object: Rc<Box<Object>>,
     pub start: usize,
     pub end: usize,

--- a/lib/core/src/rp_channel.rs
+++ b/lib/core/src/rp_channel.rs
@@ -17,8 +17,7 @@ impl RpChannel {
         use self::RpChannel::*;
 
         match *self {
-            Unary { ref ty, .. } => ty,
-            Streaming { ref ty, .. } => ty,
+            Unary { ref ty, .. } | Streaming { ref ty, .. } => ty,
         }
     }
 

--- a/lib/core/src/rp_decl.rs
+++ b/lib/core/src/rp_decl.rs
@@ -81,39 +81,39 @@ impl RpDecl {
     }
 
     /// Convert a declaration into its registered types.
-    pub fn into_reg(&self) -> Vec<RpReg> {
+    pub fn to_reg(&self) -> Vec<RpReg> {
         use self::RpDecl::*;
 
         let mut out = Vec::new();
 
         match *self {
             Type(ref ty) => {
-                out.push(RpReg::Type(ty.clone()));
+                out.push(RpReg::Type(Rc::clone(ty)));
             }
             Interface(ref interface) => {
                 for sub_type in interface.sub_types.values() {
-                    out.push(RpReg::SubType(interface.clone(), sub_type.clone()));
-                    out.extend(sub_type.decls.iter().flat_map(|d| d.into_reg()));
+                    out.push(RpReg::SubType(Rc::clone(interface), Rc::clone(sub_type)));
+                    out.extend(sub_type.decls.iter().flat_map(|d| d.to_reg()));
                 }
 
-                out.push(RpReg::Interface(interface.clone()));
+                out.push(RpReg::Interface(Rc::clone(interface)));
             }
             Enum(ref en) => {
                 for variant in &en.variants {
-                    out.push(RpReg::EnumVariant(en.clone(), variant.clone()));
+                    out.push(RpReg::EnumVariant(Rc::clone(en), Rc::clone(variant)));
                 }
 
-                out.push(RpReg::Enum(en.clone()));
+                out.push(RpReg::Enum(Rc::clone(en)));
             }
             Tuple(ref tuple) => {
-                out.push(RpReg::Tuple(tuple.clone()));
+                out.push(RpReg::Tuple(Rc::clone(tuple)));
             }
             Service(ref service) => {
-                out.push(RpReg::Service(service.clone()));
+                out.push(RpReg::Service(Rc::clone(service)));
             }
         }
 
-        out.extend(self.decls().flat_map(|d| d.into_reg()));
+        out.extend(self.decls().flat_map(|d| d.to_reg()));
         out
     }
 

--- a/lib/core/src/rp_decl.rs
+++ b/lib/core/src/rp_decl.rs
@@ -1,6 +1,6 @@
 //! Model for declarations
 
-use super::{Loc, RpEnumBody, RpInterfaceBody, RpName, RpReg, RpServiceBody, RpTupleBody,
+use super::{Loc, Pos, RpEnumBody, RpInterfaceBody, RpName, RpReg, RpServiceBody, RpTupleBody,
             RpTypeBody};
 use std::fmt;
 use std::rc::Rc;
@@ -8,11 +8,11 @@ use std::slice;
 
 /// Iterator over declarations.
 pub struct Decls<'a> {
-    iter: slice::Iter<'a, Rc<Loc<RpDecl>>>,
+    iter: slice::Iter<'a, RpDecl>,
 }
 
 impl<'a> Iterator for Decls<'a> {
-    type Item = &'a Rc<Loc<RpDecl>>;
+    type Item = &'a RpDecl;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next()
@@ -127,6 +127,19 @@ impl RpDecl {
             Enum(_) => "enum",
             Tuple(_) => "tuple",
             Service(_) => "service",
+        }
+    }
+
+    /// Get the position of the declaration.
+    pub fn pos(&self) -> &Pos {
+        use self::RpDecl::*;
+
+        match *self {
+            Type(ref body) => body.pos(),
+            Interface(ref body) => body.pos(),
+            Enum(ref body) => body.pos(),
+            Tuple(ref body) => body.pos(),
+            Service(ref body) => body.pos(),
         }
     }
 }

--- a/lib/core/src/rp_endpoint.rs
+++ b/lib/core/src/rp_endpoint.rs
@@ -1,6 +1,7 @@
 //! Model for endpoints
 
 use super::{Attributes, Loc, RpChannel};
+use linked_hash_map::LinkedHashMap;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct RpEndpoint {
@@ -13,7 +14,7 @@ pub struct RpEndpoint {
     /// Attributes associated with the endpoint.
     pub attributes: Attributes,
     /// Request type that this endpoint expects.
-    pub request: Option<Loc<RpChannel>>,
+    pub arguments: LinkedHashMap<Loc<String>, Loc<RpChannel>>,
     /// Response type that this endpoint responds with.
     pub response: Option<Loc<RpChannel>>,
 }

--- a/lib/core/src/rp_endpoint.rs
+++ b/lib/core/src/rp_endpoint.rs
@@ -1,6 +1,6 @@
 //! Model for endpoints
 
-use super::{Loc, RpChannel};
+use super::{Attributes, Loc, RpChannel};
 
 #[derive(Debug, Clone, Serialize)]
 pub struct RpEndpoint {
@@ -10,6 +10,8 @@ pub struct RpEndpoint {
     pub name: String,
     /// Comments for documentation.
     pub comment: Vec<String>,
+    /// Attributes associated with the endpoint.
+    pub attributes: Attributes,
     /// Request type that this endpoint expects.
     pub request: Option<Loc<RpChannel>>,
     /// Response type that this endpoint responds with.

--- a/lib/core/src/rp_enum_type.rs
+++ b/lib/core/src/rp_enum_type.rs
@@ -23,8 +23,7 @@ impl RpEnumType {
         use self::RpEnumType::*;
 
         match *self {
-            String => RpType::String,
-            Generated => RpType::String,
+            String | Generated => RpType::String,
         }
     }
 

--- a/lib/core/src/rp_file.rs
+++ b/lib/core/src/rp_file.rs
@@ -2,23 +2,22 @@
 
 use super::{Loc, RpDecl, RpOptionDecl};
 use std::collections::LinkedList;
-use std::rc::Rc;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct RpFile {
     pub comment: Vec<String>,
     pub options: Vec<Loc<RpOptionDecl>>,
-    pub decls: Vec<Rc<Loc<RpDecl>>>,
+    pub decls: Vec<RpDecl>,
 }
 
 /// Iterator over all declarations in a file.
 #[allow(linkedlist)]
 pub struct ForEachDecl<'a> {
-    queue: LinkedList<&'a Rc<Loc<RpDecl>>>,
+    queue: LinkedList<&'a RpDecl>,
 }
 
 impl<'a> Iterator for ForEachDecl<'a> {
-    type Item = &'a Rc<Loc<RpDecl>>;
+    type Item = &'a RpDecl;
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(decl) = self.queue.pop_front() {

--- a/lib/core/src/rp_file.rs
+++ b/lib/core/src/rp_file.rs
@@ -12,6 +12,7 @@ pub struct RpFile {
 }
 
 /// Iterator over all declarations in a file.
+#[allow(linkedlist)]
 pub struct ForEachDecl<'a> {
     queue: LinkedList<&'a Rc<Loc<RpDecl>>>,
 }

--- a/lib/core/src/rp_package.rs
+++ b/lib/core/src/rp_package.rs
@@ -14,7 +14,7 @@ impl RpPackage {
 
     /// Parse a package from a string.
     pub fn parse(input: &str) -> RpPackage {
-        RpPackage::new(input.split(".").map(ToOwned::to_owned).collect())
+        RpPackage::new(input.split('.').map(ToOwned::to_owned).collect())
     }
 
     pub fn empty() -> RpPackage {

--- a/lib/core/src/rp_package_format.rs
+++ b/lib/core/src/rp_package_format.rs
@@ -10,7 +10,7 @@ impl<'a> fmt::Display for RpPackageFormat<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)?;
 
-        if let Some(ref version) = self.1 {
+        if let Some(version) = self.1 {
             write!(f, "-{}", version)?;
         }
 

--- a/lib/core/src/rp_required_package.rs
+++ b/lib/core/src/rp_required_package.rs
@@ -20,7 +20,7 @@ impl RpRequiredPackage {
 
     /// Parse the package requirement from a string.
     pub fn parse(input: &str) -> Result<RpRequiredPackage> {
-        let mut it = input.splitn(2, "@").into_iter();
+        let mut it = input.splitn(2, '@').into_iter();
 
         let package = it.next().map(RpPackage::parse).unwrap_or_else(
             RpPackage::empty,

--- a/lib/core/src/rp_sub_type.rs
+++ b/lib/core/src/rp_sub_type.rs
@@ -12,15 +12,13 @@ pub struct RpSubType {
     pub decls: Vec<Rc<Loc<RpDecl>>>,
     pub fields: Vec<Loc<RpField>>,
     pub codes: Vec<Loc<RpCode>>,
-    pub names: Vec<Loc<String>>,
+    pub sub_type_name: Option<Loc<String>>,
 }
 
 impl RpSubType {
     pub fn name(&self) -> &str {
-        self.names
-            .iter()
-            .map(|t| t.value().as_str())
-            .nth(0)
-            .unwrap_or(&self.local_name)
+        self.sub_type_name.as_ref().map(|t| t.as_str()).unwrap_or(
+            &self.local_name,
+        )
     }
 }

--- a/lib/core/src/rp_sub_type.rs
+++ b/lib/core/src/rp_sub_type.rs
@@ -1,7 +1,6 @@
 //! Model for sub-types
 
 use super::{Loc, RpCode, RpDecl, RpField, RpName};
-use std::rc::Rc;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct RpSubType {
@@ -9,7 +8,7 @@ pub struct RpSubType {
     pub local_name: String,
     pub comment: Vec<String>,
     /// Inner declarations.
-    pub decls: Vec<Rc<Loc<RpDecl>>>,
+    pub decls: Vec<RpDecl>,
     pub fields: Vec<Loc<RpField>>,
     pub codes: Vec<Loc<RpCode>>,
     pub sub_type_name: Option<Loc<String>>,

--- a/lib/core/src/rp_tuple_body.rs
+++ b/lib/core/src/rp_tuple_body.rs
@@ -22,7 +22,7 @@ impl<'a> Iterator for Fields<'a> {
 }
 
 impl RpTupleBody {
-    pub fn fields<'a>(&'a self) -> Fields {
+    pub fn fields(&self) -> Fields {
         Fields { iter: self.fields.iter() }
     }
 }

--- a/lib/core/src/rp_type_body.rs
+++ b/lib/core/src/rp_type_body.rs
@@ -25,7 +25,7 @@ impl<'a> Iterator for Fields<'a> {
 }
 
 impl RpTypeBody {
-    pub fn fields<'a>(&'a self) -> Fields {
+    pub fn fields(&self) -> Fields {
         Fields { iter: self.fields.iter() }
     }
 }

--- a/lib/core/src/rp_value.rs
+++ b/lib/core/src/rp_value.rs
@@ -1,6 +1,6 @@
 //! Value of models
 
-use super::{Loc, RpEnumOrdinal, RpNumber};
+use super::{Loc, RpEnumOrdinal, RpNumber, RpType};
 use errors::*;
 use std::fmt;
 
@@ -12,6 +12,7 @@ pub enum RpValue {
     Boolean(bool),
     Identifier(String),
     Array(Vec<Loc<RpValue>>),
+    Type(RpType),
 }
 
 impl RpValue {
@@ -52,6 +53,7 @@ impl fmt::Display for RpValue {
             RpValue::Boolean(_) => "<boolean>",
             RpValue::Identifier(_) => "<identifier>",
             RpValue::Array(_) => "<array>",
+            RpValue::Type(ref ty) => return ty.fmt(f),
         };
 
         write!(f, "{}", out)

--- a/lib/core/src/rp_value.rs
+++ b/lib/core/src/rp_value.rs
@@ -34,7 +34,7 @@ impl RpValue {
         }
     }
 
-    pub fn to_ordinal(self) -> Result<RpEnumOrdinal> {
+    pub fn into_ordinal(self) -> Result<RpEnumOrdinal> {
         let ordinal = match self {
             RpValue::String(value) => RpEnumOrdinal::String(value),
             _ => return Err(ErrorKind::InvalidOrdinal.into()),

--- a/lib/lexer/lib.rs
+++ b/lib/lexer/lib.rs
@@ -517,6 +517,7 @@ impl<'input> Lexer<'input> {
                     ',' => Token::Comma,
                     '.' => Token::Dot,
                     '?' => Token::QuestionMark,
+                    '#' => Token::Hash,
                     '=' => Token::Equal,
                     '_' | 'a'...'z' => return Some(self.identifier(start)),
                     'A'...'Z' => return Some(self.type_identifier(start)),

--- a/lib/lexer/token.rs
+++ b/lib/lexer/token.rs
@@ -20,6 +20,7 @@ pub enum Token<'input> {
     Dot,
     Scope,
     QuestionMark,
+    Hash,
     RightArrow,
     CodeOpen,
     CodeClose,

--- a/lib/parser/src/lib.rs
+++ b/lib/parser/src/lib.rs
@@ -125,7 +125,7 @@ mod tests {
         parser::parse_File(&new_context(), parse(input)).unwrap()
     }
 
-    fn parse_member(input: &'static str) -> Loc<Member> {
+    fn parse_member(input: &'static str) -> Member {
         parser::parse_Member(&new_context(), parse(input)).unwrap()
     }
 
@@ -248,7 +248,7 @@ mod tests {
 
     #[test]
     fn test_option_decl() {
-        let member = parse_member("option foo_bar_baz = true;").take();
+        let member = parse_member("option foo_bar_baz = true;");
 
         if let Member::Option(option) = member {
             assert_eq!("foo_bar_baz", option.name);

--- a/lib/parser/src/lib.rs
+++ b/lib/parser/src/lib.rs
@@ -125,8 +125,8 @@ mod tests {
         parser::parse_File(&new_context(), parse(input)).unwrap()
     }
 
-    fn parse_member(input: &'static str) -> Member {
-        parser::parse_Member(&new_context(), parse(input)).unwrap()
+    fn parse_member(input: &'static str) -> TypeMember {
+        parser::parse_TypeMember(&new_context(), parse(input)).unwrap()
     }
 
     fn parse_type_spec(input: &'static str) -> Type {
@@ -250,7 +250,7 @@ mod tests {
     fn test_option_decl() {
         let member = parse_member("option foo_bar_baz = true;");
 
-        if let Member::Option(option) = member {
+        if let TypeMember::Option(option) = member {
             assert_eq!("foo_bar_baz", option.name);
             assert_eq!(Value::Boolean(true), *option.value.value());
             return;

--- a/lib/parser/src/parser.lalrpop
+++ b/lib/parser/src/parser.lalrpop
@@ -310,12 +310,13 @@ SubType: Loc<SubType<'input>> = {
 };
 
 pub Value: Value<'input> = {
-    "[" <values:ZeroOrMore<",", Loc<Value>>> "]" => Value::Array(values),
+    "(" <values:ZeroOrMore<",", Loc<Value>>> ")" => Value::Array(values),
     <string:"string"> => Value::String(string),
     <number:number> => Value::Number(number),
     <true> => Value::Boolean(true),
     <false> => Value::Boolean(false),
     <ident:ident> => Value::Identifier(ident),
+    <ty:TypeSpec> => Value::Type(ty),
 };
 
 pub TypeSpec: Type = {
@@ -363,11 +364,6 @@ Attribute: Attribute<'input> = {
 };
 
 AttributeItem: AttributeItem<'input> = {
-    <ident:Loc<ident>> "=" <ty:Loc<TypeSpec>> => AttributeItem::NameType {
-        name: ident,
-        ty: ty,
-    },
-
     <ident:Loc<ident>> "=" <value:Loc<Value>> => AttributeItem::NameValue {
         name: ident,
         value: value,

--- a/lib/parser/src/parser.lalrpop
+++ b/lib/parser/src/parser.lalrpop
@@ -49,7 +49,7 @@ Decl: Decl<'input> = {
 Enum: EnumBody<'input> =
     "enum" <name:TypeIdent> <ty:("as" Loc<TypeSpec>)?> "{"
         <variants:Item<EnumVariant>*>
-        <members:Member*>
+        <members:EnumMember*>
     "}" =>
     EnumBody {
         name: name,
@@ -58,9 +58,15 @@ Enum: EnumBody<'input> =
         members: members,
     };
 
+EnumMember: EnumMember<'input> = {
+    <option:Loc<OptionDecl>> => EnumMember::Option(option),
+    <code:Loc<Code>> => EnumMember::Code(code),
+    <decl:Decl> => EnumMember::InnerDecl(decl),
+};
+
 Interface: InterfaceBody<'input> =
     "interface" <name:TypeIdent> "{"
-      <members:Member*>
+      <members:TypeMember*>
       <sub_types:Item<SubType>*>
     "}" =>
     InterfaceBody {
@@ -71,7 +77,7 @@ Interface: InterfaceBody<'input> =
 
 Type: TypeBody<'input> =
     "type" <name:TypeIdent> "{"
-        <members:Member*>
+        <members:TypeMember*>
     "}" =>
     TypeBody {
         name: name,
@@ -80,7 +86,7 @@ Type: TypeBody<'input> =
 
 Tuple: TupleBody<'input> =
     "tuple" <name:TypeIdent> "{"
-        <members:Member*>
+        <members:TypeMember*>
     "}" =>
     TupleBody {
         name: name,
@@ -175,11 +181,11 @@ Modifier: RpModifier =
     <modifier:"?"?> =>
     modifier.map(|_| RpModifier::Optional).unwrap_or(RpModifier::Required);
 
-pub Member: Member<'input> = {
-    <field:Item<Field>> => Member::Field(field),
-    <option:Loc<OptionDecl>> => Member::Option(option),
-    <code:Loc<Code>> => Member::Code(code),
-    <decl:Decl> => Member::InnerDecl(decl),
+pub TypeMember: TypeMember<'input> = {
+    <field:Item<Field>> => TypeMember::Field(field),
+    <option:Loc<OptionDecl>> => TypeMember::Option(option),
+    <code:Loc<Code>> => TypeMember::Code(code),
+    <decl:Decl> => TypeMember::InnerDecl(decl),
 };
 
 Code: Code<'input> =
@@ -207,7 +213,7 @@ OptionDecl: OptionDecl<'input> =
 
 SubType: SubType<'input> = {
     <name:Loc<TypeIdent>> <alias:("as" Loc<Value>)?> "{"
-        <members:Member*>
+        <members:TypeMember*>
     "}" =>
     SubType {
         name: name,

--- a/lib/parser/src/parser.lalrpop
+++ b/lib/parser/src/parser.lalrpop
@@ -147,7 +147,9 @@ Endpoint: Loc<Endpoint<'input>> = {
     <comment:"///"?>
     <attributes:Loc<Attribute>*>
     <s:@L>
-    <id:Loc<ident>> "(" <request:Loc<Channel>?> ")" <response:("->" Loc<Channel>)?>
+    <id:Loc<ident>> "("
+        <arguments:ZeroOrMore<",", EndpointArgument>>
+    ")" <response:("->" Loc<Channel>)?>
     <alias:FieldAlias?>
     <e:@R>
     ";" => {
@@ -157,7 +159,7 @@ Endpoint: Loc<Endpoint<'input>> = {
             attributes: attributes,
             alias: alias,
             options: vec![],
-            request: request,
+            arguments: arguments,
             response: response.map(|r| r.1),
         }, (input_object.clone(), s, e))
     },
@@ -165,7 +167,9 @@ Endpoint: Loc<Endpoint<'input>> = {
     <comment:"///"?>
     <attributes:Loc<Attribute>*>
     <s:@L>
-    <id:Loc<ident>> "(" <request:Loc<Channel>?> ")" <response:("->" Loc<Channel>)?>
+    <id:Loc<ident>> "("
+        <arguments:ZeroOrMore<",", EndpointArgument>>
+    ")" <response:("->" Loc<Channel>)?>
     <alias:FieldAlias?> "{"
         <options:Loc<OptionDecl>*>
     "}"
@@ -176,9 +180,15 @@ Endpoint: Loc<Endpoint<'input>> = {
             attributes: attributes,
             alias: alias,
             options: options,
-            request: request,
+            arguments: arguments,
             response: response.map(|r| r.1),
         }, (input_object.clone(), s, e))
+    },
+};
+
+EndpointArgument: (Loc<&'input str>, Loc<Channel>) = {
+    <name:Loc<ident>> ":" <channel:Loc<Channel>> => {
+        (name, channel)
     },
 };
 
@@ -193,7 +203,7 @@ Channel: Channel = {
                 ty: ty
             }
         }
-    }
+    },
 };
 
 FieldAlias: String = {
@@ -353,6 +363,11 @@ Attribute: Attribute<'input> = {
 };
 
 AttributeItem: AttributeItem<'input> = {
+    <ident:Loc<ident>> "=" <ty:Loc<TypeSpec>> => AttributeItem::NameType {
+        name: ident,
+        ty: ty,
+    },
+
     <ident:Loc<ident>> "=" <value:Loc<Value>> => AttributeItem::NameValue {
         name: ident,
         value: value,

--- a/lib/parser/src/parser.lalrpop
+++ b/lib/parser/src/parser.lalrpop
@@ -145,45 +145,41 @@ pub ServiceMember: ServiceMember<'input> = {
 
 Endpoint: Loc<Endpoint<'input>> = {
     <comment:"///"?>
+    <attributes:Loc<Attribute>*>
     <s:@L>
-    <head:ServiceEndpointHead> ";"
-    <e:@R> => {
-        let (id, alias, request, response) = head;
-
+    <id:Loc<ident>> "(" <request:Loc<Channel>?> ")" <response:("->" Loc<Channel>)?>
+    <alias:FieldAlias?>
+    <e:@R>
+    ";" => {
         Loc::new(Endpoint {
             id: id,
             comment: comment.unwrap_or_else(Vec::new),
+            attributes: attributes,
             alias: alias,
             options: vec![],
             request: request,
-            response: response,
+            response: response.map(|r| r.1),
         }, (input_object.clone(), s, e))
     },
 
     <comment:"///"?>
+    <attributes:Loc<Attribute>*>
     <s:@L>
-    <head:ServiceEndpointHead> "{"
+    <id:Loc<ident>> "(" <request:Loc<Channel>?> ")" <response:("->" Loc<Channel>)?>
+    <alias:FieldAlias?> "{"
         <options:Loc<OptionDecl>*>
     "}"
     <e:@R> => {
-        let (id, alias, request, response) = head;
-
         Loc::new(Endpoint {
             id: id,
             comment: comment.unwrap_or_else(Vec::new),
+            attributes: attributes,
             alias: alias,
             options: options,
             request: request,
-            response: response,
+            response: response.map(|r| r.1),
         }, (input_object.clone(), s, e))
     },
-};
-
-ServiceEndpointHead: (Loc<&'input str>, Option<String>, Option<Loc<Channel>>, Option<Loc<Channel>>) = {
-    <id:Loc<ident>> "(" <request:Loc<Channel>?> ")"
-    <response:("->" Loc<Channel>)?>
-    <alias:FieldAlias?>
-    => (id, alias, request, response.map(|r| r.1)),
 };
 
 Channel: Channel = {
@@ -347,6 +343,26 @@ Name: Name = {
     },
 };
 
+Attribute: Attribute<'input> = {
+    "#" "[" <ident:Loc<ident>>  "]" => {
+        Attribute::Word(ident)
+    },
+    "#" "[" <ident:Loc<ident>> "(" <name_value:OneOrMore<",", AttributeItem>> ")" "]" => {
+        Attribute::List(ident, name_value)
+    },
+};
+
+AttributeItem: AttributeItem<'input> = {
+    <ident:Loc<ident>> "=" <value:Loc<Value>> => AttributeItem::NameValue {
+        name: ident,
+        value: value,
+    },
+
+    <ident:Loc<ident>> => {
+        AttributeItem::Word(ident)
+    },
+};
+
 /// Zero or more matching, separated by a token.
 ZeroOrMore<Sep, T>: Vec<T> = {
     <value:OneOrMore<Sep, T>?> => {
@@ -395,6 +411,7 @@ extern {
         ";" => Token::SemiColon,
         ":" => Token::Colon,
         "?" => Token::QuestionMark,
+        "#" => Token::Hash,
         "->" => Token::RightArrow,
         "," => Token::Comma,
         "." => Token::Dot,

--- a/lib/parser/src/parser.lalrpop
+++ b/lib/parser/src/parser.lalrpop
@@ -3,28 +3,28 @@ use core::{RpNumber, Loc, RpModifier, RpPackage, Object, VersionReq};
 use std::rc::Rc;
 use ast::*;
 use lexer::{self, Token};
-use super::utils::*;
+use super::utils::strip_code_block;
 
 grammar<'input, 'object>(input_object: &'object Rc<Box<Object>>);
 
-pub File: File<'input> = {
+pub File: File<'input> =
     <comment:"//!"?>
     <uses:Loc<Use>*>
     <options:Loc<OptionDecl>*>
-    <decls:Loc<Decl>*> => File {
-        comment: comment.unwrap_or_else(Vec::new),
-        options: options,
-        uses: uses,
-        decls: decls,
-    },
+    <decls:Decl*> => {
+        File {
+            comment: comment.unwrap_or_else(Vec::new),
+            uses: uses,
+            options: options,
+            decls: decls,
+        }
 };
 
 Use: UseDecl<'input> =
     "use" <package:Loc<Package>>
         <version_req:Loc<"string">?>
         <alias:Loc<UseAlias>?>
-    ";" =>
-{
+    ";" => {
     UseDecl {
         package: package,
         version_req: version_req,
@@ -34,103 +34,70 @@ Use: UseDecl<'input> =
 
 UseAlias: &'input str = "as" <value:ident> => value;
 
-Package: RpPackage =
-    <parts:OneOrMore<".", ident>> =>
-{
+Package: RpPackage = <parts:OneOrMore<".", ident>> => {
     RpPackage::new(parts.into_iter().map(ToOwned::to_owned).collect())
 };
 
 Decl: Decl<'input> = {
-    <en:Enum> => Decl::Enum(en),
-    <interface:Interface> => Decl::Interface(interface),
-    <ty:Type> => Decl::Type(ty),
-    <tuple:Tuple> => Decl::Tuple(tuple),
-    <service:Service> => Decl::Service(service),
+    <en:Item<Enum>> => Decl::Enum(en),
+    <interface:Item<Interface>> => Decl::Interface(interface),
+    <ty:Item<Type>> => Decl::Type(ty),
+    <tuple:Item<Tuple>> => Decl::Tuple(tuple),
+    <service:Item<Service>> => Decl::Service(service),
 };
 
-Enum: Loc<EnumBody<'input>> =
-    <comment:"///"?>
-    <s:@L>
+Enum: EnumBody<'input> =
     "enum" <name:TypeIdent> <ty:("as" Loc<TypeSpec>)?> "{"
-        <variants:EnumVariant*>
+        <variants:Item<EnumVariant>*>
         <members:Member*>
-    "}"
-    <e:@R> =>
-{
-    Loc::new(EnumBody {
+    "}" =>
+    EnumBody {
         name: name,
-        comment: comment.unwrap_or_else(Vec::new),
         ty: ty.map(|ty| ty.1),
         variants: variants,
         members: members,
-    }, (input_object.clone(), s, e))
-};
+    };
 
-Interface: Loc<InterfaceBody<'input>> = {
-    <comment:"///"?>
-    <s:@L>
+Interface: InterfaceBody<'input> =
     "interface" <name:TypeIdent> "{"
       <members:Member*>
-      <sub_types:SubType*>
-    "}"
-    <e:@R> =>
-    {
-        Loc::new(InterfaceBody {
-            name: name,
-            comment: comment.unwrap_or_else(Vec::new),
-            members: members,
-            sub_types: sub_types,
-        }, (input_object.clone(), s, e))
-    },
-};
+      <sub_types:Item<SubType>*>
+    "}" =>
+    InterfaceBody {
+        name: name,
+        members: members,
+        sub_types: sub_types,
+    };
 
-Type: Loc<TypeBody<'input>> =
-    <comment:"///"?>
-    <s:@L>
+Type: TypeBody<'input> =
     "type" <name:TypeIdent> "{"
         <members:Member*>
-    "}"
-    <e:@R> =>
-{
-    Loc::new(TypeBody {
+    "}" =>
+    TypeBody {
         name: name,
-        comment: comment.unwrap_or_else(Vec::new),
         members: members,
-    }, (input_object.clone(), s, e))
-};
+    };
 
-Tuple: Loc<TupleBody<'input>> =
-    <comment:"///"?>
-    <s:@L>
+Tuple: TupleBody<'input> =
     "tuple" <name:TypeIdent> "{"
         <members:Member*>
-    "}"
-    <e:@R> =>
-{
-    Loc::new(TupleBody {
+    "}" =>
+    TupleBody {
         name: name,
-        comment: comment.unwrap_or_else(Vec::new),
         members: members,
-    }, (input_object.clone(), s, e))
-};
+    };
 
-Service: Loc<ServiceBody<'input>> =
-    <comment:"///"?>
-    <s:@L>
+Service: ServiceBody<'input> =
     "service" <name:TypeIdent> "{"
         <members:ServiceMember*>
-    "}"
-    <e:@R> =>
-{
-    Loc::new(ServiceBody {
+    "}" =>
+    ServiceBody {
         name: name,
-        comment: comment.unwrap_or_else(Vec::new),
         members: members,
-    }, (input_object.clone(), s, e))
-};
+    };
 
 pub ServiceMember: ServiceMember<'input> = {
-    <endpoint:Endpoint> => {
+    <endpoint:Item<Endpoint>> => {
         ServiceMember::Endpoint(endpoint)
     },
 
@@ -138,59 +105,45 @@ pub ServiceMember: ServiceMember<'input> = {
         ServiceMember::Option(option)
     },
 
-    <decl:Loc<Decl>> => {
+    <decl:Decl> => {
         ServiceMember::InnerDecl(decl)
     },
 };
 
-Endpoint: Loc<Endpoint<'input>> = {
-    <comment:"///"?>
-    <attributes:Loc<Attribute>*>
-    <s:@L>
+Endpoint: Endpoint<'input> = {
     <id:Loc<ident>> "("
         <arguments:ZeroOrMore<",", EndpointArgument>>
     ")" <response:("->" Loc<Channel>)?>
     <alias:FieldAlias?>
-    <e:@R>
     ";" => {
-        Loc::new(Endpoint {
+        Endpoint {
             id: id,
-            comment: comment.unwrap_or_else(Vec::new),
-            attributes: attributes,
             alias: alias,
             options: vec![],
             arguments: arguments,
             response: response.map(|r| r.1),
-        }, (input_object.clone(), s, e))
+        }
     },
 
-    <comment:"///"?>
-    <attributes:Loc<Attribute>*>
-    <s:@L>
     <id:Loc<ident>> "("
         <arguments:ZeroOrMore<",", EndpointArgument>>
     ")" <response:("->" Loc<Channel>)?>
     <alias:FieldAlias?> "{"
         <options:Loc<OptionDecl>*>
-    "}"
-    <e:@R> => {
-        Loc::new(Endpoint {
+    "}" => {
+        Endpoint {
             id: id,
-            comment: comment.unwrap_or_else(Vec::new),
-            attributes: attributes,
             alias: alias,
             options: options,
             arguments: arguments,
             response: response.map(|r| r.1),
-        }, (input_object.clone(), s, e))
+        }
     },
 };
 
-EndpointArgument: (Loc<&'input str>, Loc<Channel>) = {
-    <name:Loc<ident>> ":" <channel:Loc<Channel>> => {
-        (name, channel)
-    },
-};
+EndpointArgument: (Loc<&'input str>, Loc<Channel>) =
+    <name:Loc<ident>> ":" <channel:Loc<Channel>> =>
+    (name, channel);
 
 Channel: Channel = {
     <stream:stream?> <ty:TypeSpec> => {
@@ -211,101 +164,62 @@ FieldAlias: String = {
     "as" <value:"string"> => value,
 };
 
-EnumVariant: Loc<EnumVariant<'input>> =
-    <comment:"///"?>
-    <s:@L>
-    <name:Loc<TypeIdent>> <argument:("as" Loc<Value>)?> ";"
-    <e:@R> =>
-{
-    Loc::new(EnumVariant {
+EnumVariant: EnumVariant<'input> =
+    <name:Loc<TypeIdent>> <argument:("as" Loc<Value>)?> ";" =>
+    EnumVariant {
         name: name,
-        comment: comment.unwrap_or_else(Vec::new),
         argument: argument.map(|a| a.1),
-    }, (input_object.clone(), s, e))
-};
+    };
 
 Modifier: RpModifier =
     <modifier:"?"?> =>
-{
-    modifier.map(|_| RpModifier::Optional).unwrap_or(RpModifier::Required)
+    modifier.map(|_| RpModifier::Optional).unwrap_or(RpModifier::Required);
+
+pub Member: Member<'input> = {
+    <field:Item<Field>> => Member::Field(field),
+    <option:Loc<OptionDecl>> => Member::Option(option),
+    <code:Loc<Code>> => Member::Code(code),
+    <decl:Decl> => Member::InnerDecl(decl),
 };
 
-pub Member: Loc<Member<'input>> = {
-    <comment:"///"?>
-    <s:@L> <name:ident> <modifier:Modifier> ":" <ty:TypeSpec> <alias:FieldAlias?> ";" <e:@R> =>
-    {
-        let field = Field {
-            modifier: modifier,
-            name: name,
-            comment: comment.unwrap_or_else(Vec::new),
-            ty: ty,
-            field_as: alias,
-        };
+Code: Code<'input> =
+    <context:ident> "{{" <content:code> "}}" =>
+    Code {
+        context: context,
+        content: strip_code_block(content)
+    };
 
-        let member = Member::Field(field);
-        Loc::new(member, (input_object.clone(), s, e))
-    },
-
-    <s:@L> <option:OptionDecl> <e:@R> =>
-    {
-        let member = Member::Option(option);
-        Loc::new(member, (input_object.clone(), s, e))
-    },
-
-    <s:@L> <context:ident> "{{" <content:code> "}}" <e:@R> =>
-    {
-        let content = strip_code_block(content);
-        let member = Member::Code(context, content);
-        Loc::new(member, (input_object.clone(), s, e))
-    },
-
-    <s:@L> <decl:Decl> <e:@R> =>
-    {
-        let member = Member::InnerDecl(decl);
-        Loc::new(member, (input_object.clone(), s, e))
-    },
-};
+Field: Field<'input> =
+    <name:ident> <modifier:Modifier> ":" <ty:TypeSpec> <alias:FieldAlias?> ";" =>
+    Field {
+        modifier: modifier,
+        name: name,
+        ty: ty,
+        field_as: alias,
+    };
 
 OptionDecl: OptionDecl<'input> =
     option <name:ident> "=" <value:Loc<Value>> ";" =>
-{
     OptionDecl {
         name: name,
         value: value,
-    }
-};
+    };
 
-SubType: Loc<SubType<'input>> = {
-    <comment:"///"?>
-    <s:@L> 
+SubType: SubType<'input> = {
     <name:Loc<TypeIdent>> <alias:("as" Loc<Value>)?> "{"
         <members:Member*>
-    "}"
-    <e:@R> =>
-    {
-        let sub_type = SubType {
-            name: name,
-            comment: comment.unwrap_or_else(Vec::new),
-            members: members,
-            alias: alias.map(|alias| alias.1),
-        };
-
-        Loc::new(sub_type, (input_object.clone(), s, e))
+    "}" =>
+    SubType {
+        name: name,
+        members: members,
+        alias: alias.map(|alias| alias.1),
     },
 
-    <comment:"///"?>
-    <s:@L>
-    <name:Loc<TypeIdent>> <alias:("as" Loc<Value>)?> ";"
-    <e:@R> =>
-    {
-        let sub_type = SubType {
-            name: name,
-            comment: comment.unwrap_or_else(Vec::new),
-            members: Vec::new(),
-            alias: alias.map(|alias| alias.1),
-        };
-
-        Loc::new(sub_type, (input_object.clone(), s, e))
+    <name:Loc<TypeIdent>> <alias:("as" Loc<Value>)?> ";" =>
+    SubType {
+        name: name,
+        members: Vec::new(),
+        alias: alias.map(|alias| alias.1),
     },
 };
 
@@ -358,6 +272,7 @@ Attribute: Attribute<'input> = {
     "#" "[" <ident:Loc<ident>>  "]" => {
         Attribute::Word(ident)
     },
+
     "#" "[" <ident:Loc<ident>> "(" <name_value:OneOrMore<",", AttributeItem>> ")" "]" => {
         Attribute::List(ident, name_value)
     },
@@ -375,11 +290,9 @@ AttributeItem: AttributeItem<'input> = {
 };
 
 /// Zero or more matching, separated by a token.
-ZeroOrMore<Sep, T>: Vec<T> = {
-    <value:OneOrMore<Sep, T>?> => {
-        value.unwrap_or_else(|| vec![])
-    }
-};
+ZeroOrMore<Sep, T>: Vec<T> =
+    <value:OneOrMore<Sep, T>?> =>
+    value.unwrap_or_else(|| vec![]);
 
 /// One or more matching, separated by a token.
 OneOrMore<Sep, T>: Vec<T> = {
@@ -390,9 +303,18 @@ OneOrMore<Sep, T>: Vec<T> = {
     }
 };
 
-Loc<Inner>: Loc<Inner> = <s:@L> <inner:Inner> <e:@R> => {
-    Loc::new(inner, (input_object.clone(), s, e))
-};
+Loc<Inner>: Loc<Inner> = <s:@L> <inner:Inner> <e:@R> =>
+    Loc::new(inner, (input_object.clone(), s, e));
+
+Item<T>: Item<'input, T> =
+    <comment:"///"?>
+    <attributes:Loc<Attribute>*>
+    <s:@L> <item:T> <e:@R> =>
+    Item {
+        comment: comment.unwrap_or_else(Vec::new),
+        attributes: attributes,
+        item: Loc::new(item, (input_object.clone(), s, e))
+    };
 
 extern {
     type Location = usize;

--- a/lib/parser/src/tests/file1.reproto
+++ b/lib/parser/src/tests/file1.reproto
@@ -59,16 +59,16 @@ service Foo {
   unknown_return() -> Foo;
 
   /// UNKNOWN
-  unknown_argument(Foo);
+  unknown_argument(request: Foo);
 
   /// UNARY
-  unary(Foo) -> Foo;
+  unary(request: Foo) -> Foo;
 
   /// SERVER_STREMAING
-  server_streaming(Foo) -> stream Foo;
+  server_streaming(request: Foo) -> stream Foo;
 
   /// CLIENT_STREAMING
-  client_streaming(stream Foo) -> Foo;
+  client_streaming(request: stream Foo) -> Foo;
 
   /// BIDI_STREAMING
   #[http(method = "GET")]
@@ -76,5 +76,6 @@ service Foo {
   #[http]
   #[allow(nothing)]
   #[deny(everything)]
-  bidi_streaming(stream Foo) -> stream Foo;
+  #[foo(ty1=[string], ty2=Foo, ty3=u32)]
+  bidi_streaming(request: stream Foo) -> stream Foo;
 }

--- a/lib/parser/src/tests/file1.reproto
+++ b/lib/parser/src/tests/file1.reproto
@@ -1,16 +1,28 @@
 use foo.bar "^2";
-use foo as bar2;
+use foo.bar "^2" as bar;
+use foo.bar as bar;
 
 tuple Tuple {
-  arg: double;
-  second: double;
+  a: double;
+  b: double;
 }
 
 type Foo {
   option reserved = "foo";
 
-  name: string;
-  map: {string: u32};
+  boolean_type?: boolean;
+  string_type?: string;
+  datetime_type?: datetime;
+  unsigned_32?: u32;
+  unsigned_64?: u32;
+  signed_32?: i32;
+  signed_64?: i64;
+  float_type?: float;
+  double_type?: double;
+  bytes_type?: bytes;
+  any_type?: any;
+  array_type?: [Foo];
+  map_type?: {string: Foo};
 
   java {{
     public int hello() {
@@ -34,7 +46,35 @@ interface Bar {
 }
 
 enum Baz {
-  FIRST as "first";
-  SECOND as "second";
-  FIRST as "third";
+  First as "first";
+  Second as "second";
+  Third as "third";
+}
+
+service Foo {
+  /// UNKNOWN
+  unknown();
+
+  /// UNKNOWN
+  unknown_return() -> Foo;
+
+  /// UNKNOWN
+  unknown_argument(Foo);
+
+  /// UNARY
+  unary(Foo) -> Foo;
+
+  /// SERVER_STREMAING
+  server_streaming(Foo) -> stream Foo;
+
+  /// CLIENT_STREAMING
+  client_streaming(stream Foo) -> Foo;
+
+  /// BIDI_STREAMING
+  #[http(method = "GET")]
+  #[http(query_params = [foo, bar, baz], path = "/hello/{world}")]
+  #[http]
+  #[allow(nothing)]
+  #[deny(everything)]
+  bidi_streaming(stream Foo) -> stream Foo;
 }

--- a/lib/parser/src/tests/file1.reproto
+++ b/lib/parser/src/tests/file1.reproto
@@ -72,7 +72,7 @@ service Foo {
 
   /// BIDI_STREAMING
   #[http(method = "GET")]
-  #[http(query_params = [foo, bar, baz], path = "/hello/{world}")]
+  #[http(query_params = (foo, bar, baz), path = "/hello/{world}")]
   #[http]
   #[allow(nothing)]
   #[deny(everything)]

--- a/lib/parser/src/tests/file1.reproto
+++ b/lib/parser/src/tests/file1.reproto
@@ -1,15 +1,21 @@
+//! Package-level documentation.
+
 use foo.bar "^2";
 use foo.bar "^2" as bar;
 use foo.bar as bar;
 
+#[attribute]
 tuple Tuple {
+  #[attribute]
   a: double;
   b: double;
 }
 
+#[attribute]
 type Foo {
   option reserved = "foo";
 
+  #[attribute]
   boolean_type?: boolean;
   string_type?: string;
   datetime_type?: datetime;
@@ -31,6 +37,7 @@ type Foo {
   }}
 }
 
+#[attribute]
 interface Bar {
   option reserved = "a";
 
@@ -40,12 +47,15 @@ interface Bar {
     }
   }}
 
+  #[attribute]
   A as "foo" {
       name: string;
   }
 }
 
+#[attribute]
 enum Baz {
+  #[attribute]
   First as "first";
   Second as "second";
   Third as "third";

--- a/lib/semck/src/lib.rs
+++ b/lib/semck/src/lib.rs
@@ -103,7 +103,7 @@ where
     let mut storage = HashMap::new();
 
     for decl in decls {
-        for reg in decl.into_reg() {
+        for reg in decl.to_reg() {
             // Checked separately for each Enum.
             if let RpReg::EnumVariant(_, _) = reg {
                 continue;
@@ -201,14 +201,15 @@ fn check_endpoint_type(
     from_endpoint: &Loc<RpEndpoint>,
     to_endpoint: &Loc<RpEndpoint>,
 ) -> Result<()> {
-    check_endpoint_channel(
+    // TODO: check arguments.
+    /*check_endpoint_channel(
         component.clone(),
         violations,
         from_endpoint,
         to_endpoint,
         |e| &e.request,
         EndpointRequestChange,
-    )?;
+    )?;*/
 
     check_endpoint_channel(
         component.clone(),

--- a/lib/semck/src/lib.rs
+++ b/lib/semck/src/lib.rs
@@ -6,7 +6,6 @@ use reproto_core::{ErrorPos, Loc, RpChannel, RpDecl, RpEndpoint, RpField, RpFile
                    RpType, RpVariant, Version};
 use reproto_core::errors::*;
 use std::collections::HashMap;
-use std::rc::Rc;
 
 #[derive(Debug, Clone)]
 pub enum Component {
@@ -98,7 +97,7 @@ fn endpoints_to_map(reg: &RpReg) -> HashMap<&str, &Loc<RpEndpoint>> {
 
 fn decls_to_map<'a, I: 'a>(decls: I) -> HashMap<RpName, RpReg>
 where
-    I: IntoIterator<Item = &'a Rc<Loc<RpDecl>>>,
+    I: IntoIterator<Item = &'a RpDecl>,
 {
     let mut storage = HashMap::new();
 


### PR DESCRIPTION
This adds structural support for rust-like attributes like this:

```reproto
service MyService {
  #[http(query = (a, b, c))]
  greet() -> string;
}
```