### PR TITLE
support automatic discovery of packages

### DIFF
--- a/cli/src/ops/build.rs
+++ b/cli/src/ops/build.rs
@@ -21,11 +21,11 @@ pub fn options<'a, 'b>() -> App<'a, 'b> {
 }
 
 pub fn entry(ctx: Rc<Context>, matches: &ArgMatches) -> Result<()> {
-    let manifest = load_manifest(matches)?;
+    let mut manifest = load_manifest(matches)?;
     let lang = manifest.lang().ok_or_else(|| {
         "no language to build for, either specify in manifest under `language` or `--lang`"
     })?;
-    let mut resolver = env::resolver(&manifest)?;
+    let mut resolver = env::resolver(&mut manifest)?;
     let env = environment(ctx.clone(), lang.copy(), &manifest, resolver.as_mut())?;
 
     lang.compile(ctx, env, manifest)?;

--- a/cli/src/ops/check.rs
+++ b/cli/src/ops/check.rs
@@ -21,8 +21,8 @@ pub fn options<'a, 'b>() -> App<'a, 'b> {
 }
 
 pub fn entry(ctx: Rc<Context>, matches: &ArgMatches) -> Result<()> {
-    let manifest = build::load_manifest(matches)?;
-    let mut resolver = env::resolver(&manifest)?;
+    let mut manifest = build::load_manifest(matches)?;
+    let mut resolver = env::resolver(&mut manifest)?;
     let mut env = build::simple_config(&ctx, &manifest, resolver.as_mut())?;
 
     let mut manifest_resolver =
@@ -46,7 +46,7 @@ pub fn entry(ctx: Rc<Context>, matches: &ArgMatches) -> Result<()> {
     results.extend(build::publish_matches(
         manifest_resolver.as_mut(),
         version_override.as_ref(),
-        &manifest.publish,
+        manifest.publish.as_ref().iter().flat_map(|p| p.iter()),
     )?);
 
     results.extend(build::matches(

--- a/cli/src/ops/doc.rs
+++ b/cli/src/ops/doc.rs
@@ -12,8 +12,8 @@ pub fn options<'a, 'b>() -> App<'a, 'b> {
 }
 
 pub fn entry(ctx: Rc<Context>, matches: &ArgMatches) -> Result<()> {
-    let manifest = load_manifest(matches)?;
-    let mut resolver = env::resolver(&manifest)?;
+    let mut manifest = load_manifest(matches)?;
+    let mut resolver = env::resolver(&mut manifest)?;
     let env = simple_config(&ctx, &manifest, resolver.as_mut())?;
     ::doc::compile(env, matches, manifest).map_err(Into::into)
 }

--- a/cli/src/ops/publish.rs
+++ b/cli/src/ops/publish.rs
@@ -39,8 +39,8 @@ pub fn options<'a, 'b>() -> App<'a, 'b> {
 }
 
 pub fn entry(ctx: Rc<Context>, m: &ArgMatches) -> Result<()> {
-    let manifest = load_manifest(m)?;
-    let mut resolver = env::resolver(&manifest)?;
+    let mut manifest = load_manifest(m)?;
+    let mut resolver = env::resolver(&mut manifest)?;
     let mut env = simple_config(&ctx, &manifest, resolver.as_mut())?;
 
     let mut manifest_resolver =
@@ -58,7 +58,7 @@ pub fn entry(ctx: Rc<Context>, m: &ArgMatches) -> Result<()> {
     results.extend(publish_matches(
         manifest_resolver.as_mut(),
         version_override.as_ref(),
-        &manifest.publish,
+        manifest.publish.as_ref().iter().flat_map(|p| p.iter()),
     )?);
 
     // packages to publish from the commandline

--- a/cli/src/ops/watch.rs
+++ b/cli/src/ops/watch.rs
@@ -269,8 +269,8 @@ pub fn entry(ctx: Rc<Context>, matches: &ArgMatches, output: &Output) -> Result<
 
         let local_paths = paths.clone();
 
-        let manifest = load_manifest(matches)?;
-        let mut resolver = env::resolver(&manifest)?;
+        let mut manifest = load_manifest(matches)?;
+        let mut resolver = env::resolver(&mut manifest)?;
 
         let env = environment_with_hook(
             ctx.clone(),

--- a/lib/compile/lib.rs
+++ b/lib/compile/lib.rs
@@ -108,7 +108,7 @@ where
 
     let mut manifest = manifest::Manifest::default();
     manifest.lang = Some(lang.copy());
-    manifest.modules = modules;
+    manifest.modules = Some(modules);
     manifest.package_prefix = package_prefix;
 
     lang.compile(ctx, env, manifest)?;

--- a/lib/core/src/resolver.rs
+++ b/lib/core/src/resolver.rs
@@ -1,6 +1,6 @@
 use errors::Result;
 use std::fmt;
-use {RpPackage, RpRequiredPackage, Source, Version};
+use {RpPackage, RpRequiredPackage, RpVersionedPackage, Source, Version};
 
 /// A resolved package.
 #[derive(Debug)]
@@ -15,9 +15,7 @@ pub struct Resolved {
 #[derive(Debug)]
 pub struct ResolvedByPrefix {
     /// Package object belongs to.
-    pub package: RpPackage,
-    /// Version of package.
-    pub version: Option<Version>,
+    pub package: RpVersionedPackage,
     /// Source found.
     pub source: Source,
 }

--- a/lib/core/src/resolver.rs
+++ b/lib/core/src/resolver.rs
@@ -42,7 +42,7 @@ impl fmt::Display for Resolved {
 /// Trait that translates a required package into a set of versions and objects.
 pub trait Resolver {
     /// Resolve the specified request.
-    fn resolve(&mut self, package: &RpRequiredPackage) -> Result<Vec<Resolved>>;
+    fn resolve(&mut self, package: &RpRequiredPackage) -> Result<Option<Resolved>>;
 
     /// Resolve by prefix.
     fn resolve_by_prefix(&mut self, package: &RpPackage) -> Result<Vec<ResolvedByPrefix>>;
@@ -56,8 +56,8 @@ pub trait Resolver {
 pub struct EmptyResolver;
 
 impl Resolver for EmptyResolver {
-    fn resolve(&mut self, _package: &RpRequiredPackage) -> Result<Vec<Resolved>> {
-        Ok(vec![])
+    fn resolve(&mut self, _package: &RpRequiredPackage) -> Result<Option<Resolved>> {
+        Ok(None)
     }
 
     fn resolve_by_prefix(&mut self, _package: &RpPackage) -> Result<Vec<ResolvedByPrefix>> {

--- a/lib/core/src/resolver.rs
+++ b/lib/core/src/resolver.rs
@@ -16,6 +16,8 @@ pub struct Resolved {
 pub struct ResolvedByPrefix {
     /// Package object belongs to.
     pub package: RpPackage,
+    /// Version of package.
+    pub version: Option<Version>,
     /// Source found.
     pub source: Source,
 }
@@ -46,6 +48,11 @@ pub trait Resolver {
 
     /// Resolve by prefix.
     fn resolve_by_prefix(&mut self, package: &RpPackage) -> Result<Vec<ResolvedByPrefix>>;
+
+    /// Find packages to build.
+    /// This will internally use the `resolve_by_prefix` function, but is conditional on if a given
+    /// resolver can be used to automatically locate buildable packages.
+    fn resolve_packages(&mut self) -> Result<Vec<ResolvedByPrefix>>;
 }
 
 pub struct EmptyResolver;
@@ -56,6 +63,10 @@ impl Resolver for EmptyResolver {
     }
 
     fn resolve_by_prefix(&mut self, _package: &RpPackage) -> Result<Vec<ResolvedByPrefix>> {
+        Ok(vec![])
+    }
+
+    fn resolve_packages(&mut self) -> Result<Vec<ResolvedByPrefix>> {
         Ok(vec![])
     }
 }

--- a/lib/core/src/rp_package.rs
+++ b/lib/core/src/rp_package.rs
@@ -144,6 +144,11 @@ impl RpPackage {
             iter: self.parts.iter(),
         }
     }
+
+    /// Get the last part, if package has one.
+    pub fn last(&self) -> Option<&str> {
+        self.parts.last().map(|s| s.as_str())
+    }
 }
 
 impl fmt::Display for RpPackage {

--- a/lib/core/src/rp_versioned_package.rs
+++ b/lib/core/src/rp_versioned_package.rs
@@ -1,6 +1,7 @@
 //! A versioned package declaration
 
 use errors::Result;
+use rp_package::Parts;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;
@@ -71,6 +72,11 @@ impl RpVersionedPackage {
             package: self.package.with_naming(naming),
             ..self
         }
+    }
+
+    /// Iterate over the parts of the package.
+    pub fn parts(&self) -> Parts {
+        self.package.parts()
     }
 }
 

--- a/lib/core/src/rp_versioned_package.rs
+++ b/lib/core/src/rp_versioned_package.rs
@@ -43,6 +43,11 @@ impl RpVersionedPackage {
         }
     }
 
+    /// Check if this package starts with another package.
+    pub fn starts_with(&self, other: &RpPackage) -> bool {
+        self.package.starts_with(other)
+    }
+
     /// Convert into a package by piping the version through the provided function.
     pub fn to_package<V>(&self, version_fn: V) -> RpPackage
     where

--- a/lib/core/src/rp_versioned_package.rs
+++ b/lib/core/src/rp_versioned_package.rs
@@ -28,10 +28,18 @@ impl AsPackage for RpVersionedPackage {
 }
 
 impl RpVersionedPackage {
-    pub fn new(package: RpPackage, version: Option<Version>) -> RpVersionedPackage {
-        RpVersionedPackage {
+    pub fn new(package: RpPackage, version: Option<Version>) -> Self {
+        Self {
             package: package,
             version: version,
+        }
+    }
+
+    /// Create an empty versioned package.
+    pub fn empty() -> Self {
+        Self {
+            package: RpPackage::empty(),
+            version: None,
         }
     }
 
@@ -51,8 +59,12 @@ impl RpVersionedPackage {
         RpPackage::new(parts)
     }
 
-    pub fn without_version(self) -> RpVersionedPackage {
-        RpVersionedPackage::new(self.package, None)
+    /// Convert to a package without a version.
+    pub fn without_version(self) -> Self {
+        Self {
+            package: self.package,
+            version: None,
+        }
     }
 
     /// Replace all keyword components in this package.

--- a/lib/core/src/source.rs
+++ b/lib/core/src/source.rs
@@ -41,7 +41,8 @@ impl Readable {
         let out: Box<Read> = match *self {
             Empty => Box::new(Cursor::new(&[])),
             Bytes(ref bytes) => Box::new(Cursor::new(ArcCursor(Arc::clone(&bytes)))),
-            Path(ref path) => Box::new(File::open(path.as_ref())?),
+            Path(ref path) => Box::new(File::open(path.as_ref())
+                .map_err(|e| format!("failed to open path: {}: {}", path.display(), e))?),
             Rope(_, ref rope) => Box::new(Cursor::new(ArcCursor(Arc::new(
                 rope.to_string().into_bytes(),
             )))),

--- a/lib/env/config.rs
+++ b/lib/env/config.rs
@@ -37,7 +37,8 @@ pub struct Config {
 
 pub fn read_config<P: AsRef<Path>>(path: P) -> Result<Config> {
     let path = path.as_ref();
-    let mut f = File::open(path)?;
+    let mut f =
+        File::open(path).map_err(|e| format!("failed to open config: {}: {}", path.display(), e))?;
     let mut content = String::new();
     f.read_to_string(&mut content)?;
     let config: Config = toml::from_str(content.as_str())

--- a/lib/env/lib.rs
+++ b/lib/env/lib.rs
@@ -27,7 +27,7 @@ mod initialize;
 pub use self::config_env::ConfigEnv;
 pub use self::initialize::initialize;
 use core::errors::Result;
-use core::{Range, RelativePath, ResolvedByPrefix, Resolver, RpRequiredPackage};
+use core::{RelativePath, ResolvedByPrefix, Resolver};
 use manifest::{Lang, Language, Manifest};
 use repository::{index_from_path, index_from_url, objects_from_path, objects_from_url, Index,
                  IndexConfig, NoIndex, NoObjects, Objects, ObjectsConfig, Paths, Repository,
@@ -196,17 +196,9 @@ pub fn resolver(manifest: &mut Manifest) -> Result<Box<Resolver>> {
     if let Some(mut resolver) = path_resolver(manifest)? {
         // if there are no packages, load from path resolver.
         if manifest.packages.is_none() {
-            let mut packages = Vec::new();
-
-            for ResolvedByPrefix {
-                package, version, ..
-            } in resolver.resolve_packages()?
-            {
-                let range = version.map(|v| Range::exact(&v)).unwrap_or_else(Range::any);
-                packages.push(RpRequiredPackage::new(package, range));
+            for ResolvedByPrefix { package, source } in resolver.resolve_packages()? {
+                manifest.sources.push(manifest::Source { package, source });
             }
-
-            manifest.packages = Some(packages);
         }
 
         resolvers.push(resolver);

--- a/lib/languageserver/Cargo.toml
+++ b/lib/languageserver/Cargo.toml
@@ -16,6 +16,7 @@ reproto-core = {path = "../core", version = "0.3"}
 reproto-manifest = {path = "../manifest", version = "0.3"}
 reproto-ast = {path = "../ast", version = "0.3"}
 reproto-env = {path = "../env", version = "0.3"}
+reproto-repository = {path = "../repository", version = "0.3"}
 reproto-parser = {path = "../parser", version = "0.3"}
 reproto-lexer = {path = "../lexer", version = "0.3"}
 

--- a/lib/languageserver/lib.rs
+++ b/lib/languageserver/lib.rs
@@ -1087,9 +1087,12 @@ where
                 .try_borrow_mut()
                 .map_err(|_| "failed to access mutable workspace")?;
 
+            // NOTE: access workspace.files is intentional to only access files which are not
+            // already open.
             let loaded = match workspace.files.get(&url) {
                 Some(file) => {
                     let rope = Rope::from_str(&text);
+
                     // NOTE: must inherit read-onlyness from the source file.
                     let source =
                         Source::rope(url.clone(), rope).with_read_only(file.diag.source.read_only);
@@ -1403,8 +1406,6 @@ where
                     info!("not supported");
                 }
             };
-        } else {
-            info!("no editing");
         }
 
         self.channel.send(request_id, edit)?;
@@ -1464,7 +1465,7 @@ where
             None => return Ok(()),
         };
 
-        debug!("definition: {}: {:?}", file.url, value);
+        debug!("jump: {}: {:?}", file.url, value);
 
         match *value {
             Jump::Absolute {

--- a/lib/languageserver/lib.rs
+++ b/lib/languageserver/lib.rs
@@ -19,6 +19,7 @@ extern crate url_serde;
 mod envelope;
 mod loaded_file;
 mod models;
+mod triggers;
 mod workspace;
 
 use self::ContentType::*;

--- a/lib/languageserver/loaded_file.rs
+++ b/lib/languageserver/loaded_file.rs
@@ -57,24 +57,8 @@ impl LoadedFile {
             references: HashMap::new(),
             type_ranges: HashMap::new(),
             symbol: HashMap::new(),
-            diag: Diagnostics::new(source.clone()),
+            diag: Diagnostics::new(source),
         }
-    }
-
-    /// Reset all state in the loaded file.
-    pub fn clear(&mut self) {
-        self.jump_triggers.clear();
-        self.completion_triggers.clear();
-        self.rename_triggers.clear();
-        self.reference_triggers.clear();
-        self.prefix_ranges.clear();
-        self.implicit_prefixes.clear();
-        self.prefixes.clear();
-        self.symbols.clear();
-        self.symbol.clear();
-        self.references.clear();
-        self.type_ranges.clear();
-        self.diag.clear();
     }
 
     /// Compute a range from a span.

--- a/lib/languageserver/models.rs
+++ b/lib/languageserver/models.rs
@@ -119,8 +119,6 @@ pub struct Prefix {
     pub range: Range,
     /// The package the prefix refers to.
     pub package: RpVersionedPackage,
-    /// URL that the prefix references.
-    pub url: Url,
     /// Is this package read-only?
     pub read_only: bool,
 }

--- a/lib/languageserver/triggers.rs
+++ b/lib/languageserver/triggers.rs
@@ -1,0 +1,52 @@
+//! Data structure to handle location triggers.
+use core::Position;
+use models::Range;
+use std::collections::{BTreeMap, Bound};
+use ty;
+
+#[derive(Debug, Clone)]
+pub struct Triggers<T> {
+    triggers: BTreeMap<Position, (Range, T)>,
+}
+
+impl<T> Triggers<T> {
+    /// Create a new trigger container.
+    pub fn new() -> Self {
+        Self {
+            triggers: BTreeMap::new(),
+        }
+    }
+
+    /// Clear the given set of triggers.
+    pub fn clear(&mut self) {
+        self.triggers.clear();
+    }
+
+    /// Insert the given trigger.
+    pub fn insert(&mut self, range: Range, value: T) {
+        self.triggers.insert(range.start, (range, value));
+    }
+
+    /// Test if the given position matches a trigger in the containers.
+    pub fn find(&self, position: ty::Position) -> Option<&T> {
+        use self::Bound::*;
+
+        let end = Position {
+            line: position.line as usize,
+            col: position.character as usize,
+        };
+
+        let mut range = self.triggers.range((Unbounded, Included(&end)));
+
+        let (range, value) = match range.next_back() {
+            Some((_, &(ref range, ref value))) => (range, value),
+            None => return None,
+        };
+
+        if !range.contains(&end) {
+            return None;
+        }
+
+        Some(value)
+    }
+}

--- a/lib/languageserver/triggers.rs
+++ b/lib/languageserver/triggers.rs
@@ -17,11 +17,6 @@ impl<T> Triggers<T> {
         }
     }
 
-    /// Clear the given set of triggers.
-    pub fn clear(&mut self) {
-        self.triggers.clear();
-    }
-
     /// Insert the given trigger.
     pub fn insert(&mut self, range: Range, value: T) {
         self.triggers.insert(range.start, (range, value));

--- a/lib/repository/src/index/file_index.rs
+++ b/lib/repository/src/index/file_index.rs
@@ -60,7 +60,9 @@ impl FileIndex {
             return Ok((vec![], false));
         }
 
-        let f = File::open(&path)?;
+        let f =
+            File::open(&path).map_err(|e| format!("failed to open: {}: {}", path.display(), e))?;
+
         let reader = BufReader::new(f);
         let mut out = Vec::new();
         let mut non_match = false;
@@ -264,7 +266,7 @@ fn read_config<P: AsRef<Path> + ?Sized>(path: &P) -> Result<Config> {
     }
 
     let mut f = File::open(&config_path)
-        .map_err(|e| format!("failed to open {}: {}", config_path.display(), e))?;
+        .map_err(|e| format!("failed to config: {}: {}", config_path.display(), e))?;
 
     let mut content = String::new();
     f.read_to_string(&mut content)?;

--- a/lib/repository/src/lib.rs
+++ b/lib/repository/src/lib.rs
@@ -32,6 +32,6 @@ pub use self::index::{index_from_path, index_from_url, init_file_index, Index, I
 pub use self::objects::{objects_from_path, objects_from_url, CachedObjects, FileObjects,
                         NoObjects, Objects, ObjectsConfig};
 pub use self::repository::Repository;
-pub use self::resolver::{Paths, Resolvers};
+pub use self::resolver::{path_to_package, Packages, Paths, Resolvers};
 pub use self::sha256::{Sha256 as Digest, to_sha256 as to_checksum};
 pub use self::update::Update;

--- a/lib/repository/src/repository.rs
+++ b/lib/repository/src/repository.rs
@@ -95,12 +95,20 @@ impl Resolver for Repository {
 
         for (deployment, package) in deployments {
             if let Some(source) = self.get_object(&deployment)? {
-                out.push(ResolvedByPrefix { package, source });
+                out.push(ResolvedByPrefix {
+                    package,
+                    version: Some(deployment.version),
+                    source,
+                });
             } else {
                 return Err(format!("missing object: {}", deployment.object).into());
             }
         }
 
         Ok(out)
+    }
+
+    fn resolve_packages(&mut self) -> Result<Vec<ResolvedByPrefix>> {
+        Ok(vec![])
     }
 }

--- a/lib/repository/src/repository.rs
+++ b/lib/repository/src/repository.rs
@@ -1,7 +1,7 @@
 use super::Objects;
 use core::errors::*;
-use core::{self, Resolved, ResolvedByPrefix, Resolver, RpPackage, RpRequiredPackage, Source,
-           Version};
+use core::{self, Resolved, ResolvedByPrefix, Resolver, RpPackage, RpRequiredPackage,
+           RpVersionedPackage, Source, Version};
 use index::{Deployment, Index};
 use sha256::to_sha256;
 use update::Update;
@@ -95,11 +95,8 @@ impl Resolver for Repository {
 
         for (deployment, package) in deployments {
             if let Some(source) = self.get_object(&deployment)? {
-                out.push(ResolvedByPrefix {
-                    package,
-                    version: Some(deployment.version),
-                    source,
-                });
+                let package = RpVersionedPackage::new(package, Some(deployment.version));
+                out.push(ResolvedByPrefix { package, source });
             } else {
                 return Err(format!("missing object: {}", deployment.object).into());
             }

--- a/lib/repository/src/repository.rs
+++ b/lib/repository/src/repository.rs
@@ -66,23 +66,21 @@ impl Repository {
 }
 
 impl Resolver for Repository {
-    fn resolve(&mut self, package: &RpRequiredPackage) -> core::errors::Result<Vec<Resolved>> {
-        let mut out = Vec::new();
-
+    fn resolve(&mut self, package: &RpRequiredPackage) -> core::errors::Result<Option<Resolved>> {
         let deployments = self.index.resolve(&package.package, &package.range)?;
 
-        for deployment in deployments {
+        if let Some(deployment) = deployments.into_iter().next_back() {
             if let Some(source) = self.get_object(&deployment)? {
-                out.push(Resolved {
+                return Ok(Some(Resolved {
                     version: Some(deployment.version),
                     source,
-                });
+                }));
             } else {
                 return Err(format!("missing object: {}", deployment.object).into());
             }
         }
 
-        Ok(out)
+        Ok(None)
     }
 
     fn resolve_by_prefix(

--- a/lib/repository/src/resolver/mod.rs
+++ b/lib/repository/src/resolver/mod.rs
@@ -1,5 +1,7 @@
+mod packages;
 mod paths;
 mod resolvers;
 
-pub use self::paths::Paths;
+pub use self::packages::Packages;
+pub use self::paths::{path_to_package, Paths};
 pub use self::resolvers::Resolvers;

--- a/lib/repository/src/resolver/packages.rs
+++ b/lib/repository/src/resolver/packages.rs
@@ -1,0 +1,67 @@
+//! # Resolver where we know an exact set of packages to resolve.
+
+use core::errors::Result;
+use core::{Resolved, ResolvedByPrefix, Resolver, RpPackage, RpRequiredPackage, RpVersionedPackage,
+           Source};
+use std::collections::BTreeMap;
+
+pub struct Packages {
+    packages: BTreeMap<RpVersionedPackage, Source>,
+}
+
+impl Packages {
+    pub fn new(packages: BTreeMap<RpVersionedPackage, Source>) -> Self {
+        Self { packages }
+    }
+}
+
+impl Resolver for Packages {
+    fn resolve(&mut self, package: &RpRequiredPackage) -> Result<Option<Resolved>> {
+        let mut resolved = Vec::new();
+
+        for (p, source) in &self.packages {
+            if p.package != package.package {
+                continue;
+            }
+
+            match p.version {
+                Some(ref version) => {
+                    if !package.range.matches(version) {
+                        continue;
+                    }
+                }
+                None => {
+                    if !package.range.matches_any() {
+                        continue;
+                    }
+                }
+            }
+
+            resolved.push(Resolved {
+                version: p.version.clone(),
+                source: source.clone(),
+            });
+        }
+
+        Ok(resolved.into_iter().next_back())
+    }
+
+    fn resolve_by_prefix(&mut self, package: &RpPackage) -> Result<Vec<ResolvedByPrefix>> {
+        let mut out = Vec::new();
+
+        for (p, source) in &self.packages {
+            if p.starts_with(package) {
+                out.push(ResolvedByPrefix {
+                    package: p.clone(),
+                    source: source.clone(),
+                });
+            }
+        }
+
+        Ok(out)
+    }
+
+    fn resolve_packages(&mut self) -> Result<Vec<ResolvedByPrefix>> {
+        self.resolve_by_prefix(&RpPackage::empty())
+    }
+}

--- a/lib/repository/src/resolver/paths.rs
+++ b/lib/repository/src/resolver/paths.rs
@@ -10,8 +10,8 @@
 //! The second form is only used when a version requirement is present.
 
 use core::errors::Result;
-use core::{Range, Resolved, ResolvedByPrefix, Resolver, RpPackage, RpRequiredPackage, Source,
-           Version};
+use core::{Range, Resolved, ResolvedByPrefix, Resolver, RpPackage, RpRequiredPackage,
+           RpVersionedPackage, Source, Version};
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -217,13 +217,10 @@ impl Resolver for Paths {
                     continue;
                 }
 
+                let package = RpVersionedPackage::new(package.clone(), version);
                 let source = Source::from_path(&path);
 
-                out.push(ResolvedByPrefix {
-                    package: package.clone(),
-                    version,
-                    source,
-                });
+                out.push(ResolvedByPrefix { package, source });
             }
         }
 
@@ -254,15 +251,10 @@ impl Resolver for Paths {
 
                     let (name, version) = self.parse_stem(stem)
                         .map_err(|e| format!("bad file: {}: {}", path.display(), e.display()))?;
-                    let package = package.clone().join_part(name);
+                    let package = RpVersionedPackage::new(package.clone().join_part(name), version);
                     let source = Source::from_path(&path);
 
-                    out.push(ResolvedByPrefix {
-                        package,
-                        version,
-                        source,
-                    });
-
+                    out.push(ResolvedByPrefix { package, source });
                     continue;
                 }
 

--- a/lib/repository/src/resolver/resolvers.rs
+++ b/lib/repository/src/resolver/resolvers.rs
@@ -16,14 +16,14 @@ impl Resolvers {
 }
 
 impl Resolver for Resolvers {
-    fn resolve(&mut self, package: &RpRequiredPackage) -> Result<Vec<Resolved>> {
-        let mut out = Vec::new();
-
+    fn resolve(&mut self, package: &RpRequiredPackage) -> Result<Option<Resolved>> {
         for resolver in &mut self.resolvers.iter_mut() {
-            out.extend(resolver.resolve(package)?);
+            if let Some(resolved) = resolver.resolve(package)? {
+                return Ok(Some(resolved));
+            }
         }
 
-        Ok(out)
+        Ok(None)
     }
 
     fn resolve_by_prefix(&mut self, package: &RpPackage) -> Result<Vec<ResolvedByPrefix>> {

--- a/lib/repository/src/resolver/resolvers.rs
+++ b/lib/repository/src/resolver/resolvers.rs
@@ -1,3 +1,5 @@
+//! Multiple resolvers with combined result.
+
 use core::errors::Result;
 use core::{Resolved, ResolvedByPrefix, Resolver, RpPackage, RpRequiredPackage};
 
@@ -29,6 +31,16 @@ impl Resolver for Resolvers {
 
         for resolver in &mut self.resolvers.iter_mut() {
             out.extend(resolver.resolve_by_prefix(package)?);
+        }
+
+        Ok(out)
+    }
+
+    fn resolve_packages(&mut self) -> Result<Vec<ResolvedByPrefix>> {
+        let mut out = Vec::new();
+
+        for resolver in &mut self.resolvers.iter_mut() {
+            out.extend(resolver.resolve_packages()?);
         }
 
         Ok(out)

--- a/lib/trans/environment.rs
+++ b/lib/trans/environment.rs
@@ -543,15 +543,13 @@ impl<'e> Import for Environment<'e, CoreFlavor> {
             return Ok(existing.clone());
         }
 
-        // find all matching objects from the resolver.
-        let files = self.resolver.resolve(required)?;
-
-        let Resolved { version, source } = match files.into_iter().last() {
+        // find matching object from the resolver.
+        let Resolved { version, source } = match self.resolver.resolve(required)? {
+            Some(resolved) => resolved,
             None => {
                 self.lookup_required.insert(required.clone(), None);
                 return Ok(None);
             }
-            Some(resolved) => resolved,
         };
 
         let package = RpVersionedPackage::new(required.package.clone(), version);

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -41,7 +41,8 @@ impl Default for Config {
 
 pub fn read_config<P: AsRef<Path>>(path: P) -> Result<Config> {
     let path = path.as_ref();
-    let mut f = File::open(path)?;
+    let mut f =
+        File::open(path).map_err(|e| format!("failed to open config: {}: {}", path.display(), e))?;
     let mut content = String::new();
     f.read_to_string(&mut content)?;
 

--- a/tools/it/lib.rs
+++ b/tools/it/lib.rs
@@ -760,7 +760,8 @@ impl<'a> ProjectRunner<'a> {
             let mut expected = Vec::new();
 
             for input in inputs {
-                let f = File::open(&input).map_err(|e| format_err!("{}: {}", input.display(), e))?;
+                let f = File::open(&input)
+                    .map_err(|e| format_err!("failed to open: {}: {}", input.display(), e))?;
 
                 for line in BufReader::new(f).lines() {
                     let line = line?;


### PR DESCRIPTION
This permits omitting a `[packages]` section in `reproto.toml`, we will then traverse all paths to discovery all targets.

So given that we have the files:
* `proto/com/github/pulls-3.0.1.reproto`
* `proto/example.reproto`

And the config:

```toml
paths = ["proto"]
language = "java"
```

We would discovery the packages:
* `com.github.pulls-3.0.1`
* `example`

This would correspond to a packages section containing:

```toml
paths = ["proto"]
language = "java"

[packages]
"com.github.pulls" = "3.0.1"
"example" = "*"
```

## Motiviation

Overall it makes it easier to work with specifications in any given project. It's a fairly safe assumption that any local specifications are intended _to be built_, so flipping the default behavior is a good thing that reduces the amount of configuration and understanding that has to be done before being up and running.