### PR TITLE
rework workspace to start support for incremental rebuilds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - [automatic discovery of packages]. ([#49]).
+- language-server: manifest is now reloaded when edited.
 
 ### Fixed
 - language-server: fix range translations to handle surrogate pairs correctly ([#51]).

--- a/cli/src/ops/build.rs
+++ b/cli/src/ops/build.rs
@@ -21,13 +21,13 @@ pub fn options<'a, 'b>() -> App<'a, 'b> {
 }
 
 pub fn entry(ctx: Rc<Context>, matches: &ArgMatches) -> Result<()> {
-    let mut manifest = load_manifest(matches)?;
+    let manifest = load_manifest(matches)?;
     let lang = manifest.lang().ok_or_else(|| {
         "no language to build for, either specify in manifest under `language` or `--lang`"
     })?;
-    let mut resolver = env::resolver(&mut manifest)?;
-    let env = environment(ctx.clone(), lang.copy(), &manifest, resolver.as_mut())?;
 
+    let mut resolver = env::resolver(&manifest)?;
+    let env = environment(ctx.clone(), lang.copy(), &manifest, resolver.as_mut())?;
     lang.compile(ctx, env, manifest)?;
     Ok(())
 }

--- a/cli/src/ops/check.rs
+++ b/cli/src/ops/check.rs
@@ -21,8 +21,8 @@ pub fn options<'a, 'b>() -> App<'a, 'b> {
 }
 
 pub fn entry(ctx: Rc<Context>, matches: &ArgMatches) -> Result<()> {
-    let mut manifest = build::load_manifest(matches)?;
-    let mut resolver = env::resolver(&mut manifest)?;
+    let manifest = build::load_manifest(matches)?;
+    let mut resolver = env::resolver(&manifest)?;
     let mut env = build::simple_config(&ctx, &manifest, resolver.as_mut())?;
 
     let mut manifest_resolver =

--- a/cli/src/ops/doc.rs
+++ b/cli/src/ops/doc.rs
@@ -12,8 +12,8 @@ pub fn options<'a, 'b>() -> App<'a, 'b> {
 }
 
 pub fn entry(ctx: Rc<Context>, matches: &ArgMatches) -> Result<()> {
-    let mut manifest = load_manifest(matches)?;
-    let mut resolver = env::resolver(&mut manifest)?;
+    let manifest = load_manifest(matches)?;
+    let mut resolver = env::resolver(&manifest)?;
     let env = simple_config(&ctx, &manifest, resolver.as_mut())?;
     ::doc::compile(env, matches, manifest).map_err(Into::into)
 }

--- a/cli/src/ops/publish.rs
+++ b/cli/src/ops/publish.rs
@@ -39,8 +39,8 @@ pub fn options<'a, 'b>() -> App<'a, 'b> {
 }
 
 pub fn entry(ctx: Rc<Context>, m: &ArgMatches) -> Result<()> {
-    let mut manifest = load_manifest(m)?;
-    let mut resolver = env::resolver(&mut manifest)?;
+    let manifest = load_manifest(m)?;
+    let mut resolver = env::resolver(&manifest)?;
     let mut env = simple_config(&ctx, &manifest, resolver.as_mut())?;
 
     let mut manifest_resolver =

--- a/cli/src/ops/watch.rs
+++ b/cli/src/ops/watch.rs
@@ -269,8 +269,8 @@ pub fn entry(ctx: Rc<Context>, matches: &ArgMatches, output: &Output) -> Result<
 
         let local_paths = paths.clone();
 
-        let mut manifest = load_manifest(matches)?;
-        let mut resolver = env::resolver(&mut manifest)?;
+        let manifest = load_manifest(matches)?;
+        let mut resolver = env::resolver(&manifest)?;
 
         let env = environment_with_hook(
             ctx.clone(),

--- a/lib/core/src/lib.rs
+++ b/lib/core/src/lib.rs
@@ -71,6 +71,7 @@ pub use self::option_entry::OptionEntry;
 pub use self::options::Options;
 pub use self::relative_path::{RelativePath, RelativePathBuf};
 pub use self::resolver::{EmptyResolver, Resolved, ResolvedByPrefix, Resolver};
+pub use self::ropey::Rope;
 pub use self::rp_channel::RpChannel;
 pub use self::rp_code::{RpCode, RpContext};
 pub use self::rp_decl::{RpDecl, RpNamed};

--- a/lib/languageserver/Cargo.toml
+++ b/lib/languageserver/Cargo.toml
@@ -26,7 +26,6 @@ serde = "1.0"
 serde_derive = "1.0"
 url = "1.7"
 url_serde = "0.2"
-ropey = "0.6"
 log = "0.3"
 linked-hash-map = {version = "0.5", features = ["serde"]}
 

--- a/lib/languageserver/lib.rs
+++ b/lib/languageserver/lib.rs
@@ -1070,6 +1070,7 @@ where
                 None => return Ok(()),
             }
 
+            workspace.dirty(&url)?;
             workspace.reload()?;
         }
 

--- a/lib/languageserver/loaded_file.rs
+++ b/lib/languageserver/loaded_file.rs
@@ -39,6 +39,8 @@ pub struct LoadedFile {
     pub type_ranges: HashMap<(RpVersionedPackage, Vec<String>), Vec<Range>>,
     /// Diagnostics for this file.
     pub diag: Diagnostics,
+    /// If the file is dirty, and needs to be reloaded.
+    pub dirty: bool,
 }
 
 impl LoadedFile {
@@ -58,6 +60,7 @@ impl LoadedFile {
             type_ranges: HashMap::new(),
             symbol: HashMap::new(),
             diag: Diagnostics::new(source),
+            dirty: false,
         }
     }
 

--- a/lib/manifest/Cargo.toml
+++ b/lib/manifest/Cargo.toml
@@ -21,3 +21,4 @@ semver = {version = "0.9", features = ["serde"]}
 serde = "1.0"
 serde_derive = "1.0"
 toml = "0.4"
+log = "0.3"

--- a/lib/manifest/src/lib.rs
+++ b/lib/manifest/src/lib.rs
@@ -618,7 +618,7 @@ impl Manifest {
             let Resolved { version, source } = match resolver.resolve(&required)? {
                 Some(resolved) => resolved,
                 None => {
-                    return Err(format!("no package found for {}", required).into());
+                    return Err(format!("required package `{}` not found", required).into());
                 }
             };
 

--- a/lib/repository/src/lib.rs
+++ b/lib/repository/src/lib.rs
@@ -32,6 +32,6 @@ pub use self::index::{index_from_path, index_from_url, init_file_index, Index, I
 pub use self::objects::{objects_from_path, objects_from_url, CachedObjects, FileObjects,
                         NoObjects, Objects, ObjectsConfig};
 pub use self::repository::Repository;
-pub use self::resolver::{path_to_package, Packages, Paths, Resolvers};
+pub use self::resolver::{path_to_package, Packages, Paths, Resolvers, EXT};
 pub use self::sha256::{Sha256 as Digest, to_sha256 as to_checksum};
 pub use self::update::Update;

--- a/lib/repository/src/resolver/mod.rs
+++ b/lib/repository/src/resolver/mod.rs
@@ -3,5 +3,5 @@ mod paths;
 mod resolvers;
 
 pub use self::packages::Packages;
-pub use self::paths::{path_to_package, Paths};
+pub use self::paths::{path_to_package, Paths, EXT};
 pub use self::resolvers::Resolvers;

--- a/lib/repository/src/resolver/paths.rs
+++ b/lib/repository/src/resolver/paths.rs
@@ -17,7 +17,7 @@ use std::ffi::OsStr;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 
-const EXT: &str = "reproto";
+pub const EXT: &str = "reproto";
 const DOT_EXT: &str = ".reproto";
 
 pub struct Paths {

--- a/lib/trans/environment.rs
+++ b/lib/trans/environment.rs
@@ -54,7 +54,7 @@ where
     /// Global package prefix.
     package_prefix: Option<RpPackage>,
     /// Index resolver to use.
-    resolver: &'a mut Resolver,
+    pub resolver: &'a mut Resolver,
     /// Store required packages, to avoid unnecessary lookups.
     lookup_required: HashMap<RpRequiredPackage, Option<RpVersionedPackage>>,
     /// Loaded versioned packages.


### PR DESCRIPTION
This is a patch that starts the necessary refactoring to support incremental rebuilds with the language server.

Incremental rebuilds are when we keep track of which files that need to be rebuilt from any one given change, to improve performance when dealing with large projects.