### PR TITLE
python: use @property-based accessors for getters

### DIFF
--- a/it/allstructures/structures/default/python/test.py
+++ b/it/allstructures/structures/default/python/test.py
@@ -63,25 +63,26 @@ class RootInterface_Foo:
     return "<RootInterface_Foo>".format()
 
 class RootEnum:
-  def __init__(self, ordinal):
-    self.ordinal = ordinal
+  def __init__(self, _ordinal):
+    self._ordinal = _ordinal
 
-  def get_ordinal(self):
-    return self.ordinal
+  @property
+  def ordinal(self):
+    return self._ordinal
 
   def encode(self):
-    return self.ordinal
+    return self._ordinal
 
   @classmethod
   def decode(cls, data):
     for value in cls.__members__.values():
-      if value.ordinal == data:
+      if value._ordinal == data:
         return value
 
     raise Exception("data does not match enum")
 
   def __repr__(self):
-    return "<RootEnum ordinal:{!r}>".format(self.ordinal)
+    return "<RootEnum ordinal:{!r}>".format(self._ordinal)
 
 class RootTuple:
   def __init__(self):
@@ -145,25 +146,26 @@ class RootType_NestedInterface_Foo:
     return "<RootType_NestedInterface_Foo>".format()
 
 class RootType_NestedEnum:
-  def __init__(self, ordinal):
-    self.ordinal = ordinal
+  def __init__(self, _ordinal):
+    self._ordinal = _ordinal
 
-  def get_ordinal(self):
-    return self.ordinal
+  @property
+  def ordinal(self):
+    return self._ordinal
 
   def encode(self):
-    return self.ordinal
+    return self._ordinal
 
   @classmethod
   def decode(cls, data):
     for value in cls.__members__.values():
-      if value.ordinal == data:
+      if value._ordinal == data:
         return value
 
     raise Exception("data does not match enum")
 
   def __repr__(self):
-    return "<RootType_NestedEnum ordinal:{!r}>".format(self.ordinal)
+    return "<RootType_NestedEnum ordinal:{!r}>".format(self._ordinal)
 
 class RootType_NestedTuple:
   def __init__(self):
@@ -227,25 +229,26 @@ class RootInterface_Foo_NestedInterface_NestedFoo:
     return "<RootInterface_Foo_NestedInterface_NestedFoo>".format()
 
 class RootInterface_Foo_NestedEnum:
-  def __init__(self, ordinal):
-    self.ordinal = ordinal
+  def __init__(self, _ordinal):
+    self._ordinal = _ordinal
 
-  def get_ordinal(self):
-    return self.ordinal
+  @property
+  def ordinal(self):
+    return self._ordinal
 
   def encode(self):
-    return self.ordinal
+    return self._ordinal
 
   @classmethod
   def decode(cls, data):
     for value in cls.__members__.values():
-      if value.ordinal == data:
+      if value._ordinal == data:
         return value
 
     raise Exception("data does not match enum")
 
   def __repr__(self):
-    return "<RootInterface_Foo_NestedEnum ordinal:{!r}>".format(self.ordinal)
+    return "<RootInterface_Foo_NestedEnum ordinal:{!r}>".format(self._ordinal)
 
 class RootInterface_Foo_NestedTuple:
   def __init__(self):
@@ -309,25 +312,26 @@ class RootTuple_NestedInterface_Foo:
     return "<RootTuple_NestedInterface_Foo>".format()
 
 class RootTuple_NestedEnum:
-  def __init__(self, ordinal):
-    self.ordinal = ordinal
+  def __init__(self, _ordinal):
+    self._ordinal = _ordinal
 
-  def get_ordinal(self):
-    return self.ordinal
+  @property
+  def ordinal(self):
+    return self._ordinal
 
   def encode(self):
-    return self.ordinal
+    return self._ordinal
 
   @classmethod
   def decode(cls, data):
     for value in cls.__members__.values():
-      if value.ordinal == data:
+      if value._ordinal == data:
         return value
 
     raise Exception("data does not match enum")
 
   def __repr__(self):
-    return "<RootTuple_NestedEnum ordinal:{!r}>".format(self.ordinal)
+    return "<RootTuple_NestedEnum ordinal:{!r}>".format(self._ordinal)
 
 class RootTuple_NestedTuple:
   def __init__(self):
@@ -391,25 +395,26 @@ class RootService_NestedInterface_Foo:
     return "<RootService_NestedInterface_Foo>".format()
 
 class RootService_NestedEnum:
-  def __init__(self, ordinal):
-    self.ordinal = ordinal
+  def __init__(self, _ordinal):
+    self._ordinal = _ordinal
 
-  def get_ordinal(self):
-    return self.ordinal
+  @property
+  def ordinal(self):
+    return self._ordinal
 
   def encode(self):
-    return self.ordinal
+    return self._ordinal
 
   @classmethod
   def decode(cls, data):
     for value in cls.__members__.values():
-      if value.ordinal == data:
+      if value._ordinal == data:
         return value
 
     raise Exception("data does not match enum")
 
   def __repr__(self):
-    return "<RootService_NestedEnum ordinal:{!r}>".format(self.ordinal)
+    return "<RootService_NestedEnum ordinal:{!r}>".format(self._ordinal)
 
 class RootService_NestedTuple:
   def __init__(self):

--- a/it/allstructures/structures/default/python3/test.py
+++ b/it/allstructures/structures/default/python3/test.py
@@ -63,25 +63,26 @@ class RootInterface_Foo:
     return "<RootInterface_Foo>".format()
 
 class RootEnum:
-  def __init__(self, ordinal):
-    self.ordinal = ordinal
+  def __init__(self, _ordinal):
+    self._ordinal = _ordinal
 
-  def get_ordinal(self):
-    return self.ordinal
+  @property
+  def ordinal(self):
+    return self._ordinal
 
   def encode(self):
-    return self.ordinal
+    return self._ordinal
 
   @classmethod
   def decode(cls, data):
     for value in cls.__members__.values():
-      if value.ordinal == data:
+      if value._ordinal == data:
         return value
 
     raise Exception("data does not match enum")
 
   def __repr__(self):
-    return "<RootEnum ordinal:{!r}>".format(self.ordinal)
+    return "<RootEnum ordinal:{!r}>".format(self._ordinal)
 
 class RootTuple:
   def __init__(self):
@@ -145,25 +146,26 @@ class RootType_NestedInterface_Foo:
     return "<RootType_NestedInterface_Foo>".format()
 
 class RootType_NestedEnum:
-  def __init__(self, ordinal):
-    self.ordinal = ordinal
+  def __init__(self, _ordinal):
+    self._ordinal = _ordinal
 
-  def get_ordinal(self):
-    return self.ordinal
+  @property
+  def ordinal(self):
+    return self._ordinal
 
   def encode(self):
-    return self.ordinal
+    return self._ordinal
 
   @classmethod
   def decode(cls, data):
     for value in cls.__members__.values():
-      if value.ordinal == data:
+      if value._ordinal == data:
         return value
 
     raise Exception("data does not match enum")
 
   def __repr__(self):
-    return "<RootType_NestedEnum ordinal:{!r}>".format(self.ordinal)
+    return "<RootType_NestedEnum ordinal:{!r}>".format(self._ordinal)
 
 class RootType_NestedTuple:
   def __init__(self):
@@ -227,25 +229,26 @@ class RootInterface_Foo_NestedInterface_NestedFoo:
     return "<RootInterface_Foo_NestedInterface_NestedFoo>".format()
 
 class RootInterface_Foo_NestedEnum:
-  def __init__(self, ordinal):
-    self.ordinal = ordinal
+  def __init__(self, _ordinal):
+    self._ordinal = _ordinal
 
-  def get_ordinal(self):
-    return self.ordinal
+  @property
+  def ordinal(self):
+    return self._ordinal
 
   def encode(self):
-    return self.ordinal
+    return self._ordinal
 
   @classmethod
   def decode(cls, data):
     for value in cls.__members__.values():
-      if value.ordinal == data:
+      if value._ordinal == data:
         return value
 
     raise Exception("data does not match enum")
 
   def __repr__(self):
-    return "<RootInterface_Foo_NestedEnum ordinal:{!r}>".format(self.ordinal)
+    return "<RootInterface_Foo_NestedEnum ordinal:{!r}>".format(self._ordinal)
 
 class RootInterface_Foo_NestedTuple:
   def __init__(self):
@@ -309,25 +312,26 @@ class RootTuple_NestedInterface_Foo:
     return "<RootTuple_NestedInterface_Foo>".format()
 
 class RootTuple_NestedEnum:
-  def __init__(self, ordinal):
-    self.ordinal = ordinal
+  def __init__(self, _ordinal):
+    self._ordinal = _ordinal
 
-  def get_ordinal(self):
-    return self.ordinal
+  @property
+  def ordinal(self):
+    return self._ordinal
 
   def encode(self):
-    return self.ordinal
+    return self._ordinal
 
   @classmethod
   def decode(cls, data):
     for value in cls.__members__.values():
-      if value.ordinal == data:
+      if value._ordinal == data:
         return value
 
     raise Exception("data does not match enum")
 
   def __repr__(self):
-    return "<RootTuple_NestedEnum ordinal:{!r}>".format(self.ordinal)
+    return "<RootTuple_NestedEnum ordinal:{!r}>".format(self._ordinal)
 
 class RootTuple_NestedTuple:
   def __init__(self):
@@ -391,25 +395,26 @@ class RootService_NestedInterface_Foo:
     return "<RootService_NestedInterface_Foo>".format()
 
 class RootService_NestedEnum:
-  def __init__(self, ordinal):
-    self.ordinal = ordinal
+  def __init__(self, _ordinal):
+    self._ordinal = _ordinal
 
-  def get_ordinal(self):
-    return self.ordinal
+  @property
+  def ordinal(self):
+    return self._ordinal
 
   def encode(self):
-    return self.ordinal
+    return self._ordinal
 
   @classmethod
   def decode(cls, data):
     for value in cls.__members__.values():
-      if value.ordinal == data:
+      if value._ordinal == data:
         return value
 
     raise Exception("data does not match enum")
 
   def __repr__(self):
-    return "<RootService_NestedEnum ordinal:{!r}>".format(self.ordinal)
+    return "<RootService_NestedEnum ordinal:{!r}>".format(self._ordinal)
 
 class RootService_NestedTuple:
   def __init__(self):

--- a/it/alltypes/structures/default/python/test.py
+++ b/it/alltypes/structures/default/python/test.py
@@ -1,61 +1,75 @@
 class Entry:
-  def __init__(self, boolean_type, string_type, datetime_type, unsigned_32, unsigned_64, signed_32, signed_64, float_type, double_type, bytes_type, any_type, array_type, array_of_array_type, map_type):
-    self.boolean_type = boolean_type
-    self.string_type = string_type
-    self.datetime_type = datetime_type
-    self.unsigned_32 = unsigned_32
-    self.unsigned_64 = unsigned_64
-    self.signed_32 = signed_32
-    self.signed_64 = signed_64
-    self.float_type = float_type
-    self.double_type = double_type
-    self.bytes_type = bytes_type
-    self.any_type = any_type
-    self.array_type = array_type
-    self.array_of_array_type = array_of_array_type
-    self.map_type = map_type
+  def __init__(self, _boolean_type, _string_type, _datetime_type, _unsigned_32, _unsigned_64, _signed_32, _signed_64, _float_type, _double_type, _bytes_type, _any_type, _array_type, _array_of_array_type, _map_type):
+    self._boolean_type = _boolean_type
+    self._string_type = _string_type
+    self._datetime_type = _datetime_type
+    self._unsigned_32 = _unsigned_32
+    self._unsigned_64 = _unsigned_64
+    self._signed_32 = _signed_32
+    self._signed_64 = _signed_64
+    self._float_type = _float_type
+    self._double_type = _double_type
+    self._bytes_type = _bytes_type
+    self._any_type = _any_type
+    self._array_type = _array_type
+    self._array_of_array_type = _array_of_array_type
+    self._map_type = _map_type
 
-  def get_boolean_type(self):
-    return self.boolean_type
+  @property
+  def boolean_type(self):
+    return self._boolean_type
 
-  def get_string_type(self):
-    return self.string_type
+  @property
+  def string_type(self):
+    return self._string_type
 
-  def get_datetime_type(self):
-    return self.datetime_type
+  @property
+  def datetime_type(self):
+    return self._datetime_type
 
-  def get_unsigned_32(self):
-    return self.unsigned_32
+  @property
+  def unsigned_32(self):
+    return self._unsigned_32
 
-  def get_unsigned_64(self):
-    return self.unsigned_64
+  @property
+  def unsigned_64(self):
+    return self._unsigned_64
 
-  def get_signed_32(self):
-    return self.signed_32
+  @property
+  def signed_32(self):
+    return self._signed_32
 
-  def get_signed_64(self):
-    return self.signed_64
+  @property
+  def signed_64(self):
+    return self._signed_64
 
-  def get_float_type(self):
-    return self.float_type
+  @property
+  def float_type(self):
+    return self._float_type
 
-  def get_double_type(self):
-    return self.double_type
+  @property
+  def double_type(self):
+    return self._double_type
 
-  def get_bytes_type(self):
-    return self.bytes_type
+  @property
+  def bytes_type(self):
+    return self._bytes_type
 
-  def get_any_type(self):
-    return self.any_type
+  @property
+  def any_type(self):
+    return self._any_type
 
-  def get_array_type(self):
-    return self.array_type
+  @property
+  def array_type(self):
+    return self._array_type
 
-  def get_array_of_array_type(self):
-    return self.array_of_array_type
+  @property
+  def array_of_array_type(self):
+    return self._array_of_array_type
 
-  def get_map_type(self):
-    return self.map_type
+  @property
+  def map_type(self):
+    return self._map_type
 
   @staticmethod
   def decode(data):
@@ -221,49 +235,49 @@ class Entry:
   def encode(self):
     data = dict()
 
-    if self.boolean_type is not None:
-      data["boolean_type"] = self.boolean_type
+    if self._boolean_type is not None:
+      data["boolean_type"] = self._boolean_type
 
-    if self.string_type is not None:
-      data["string_type"] = self.string_type
+    if self._string_type is not None:
+      data["string_type"] = self._string_type
 
-    if self.datetime_type is not None:
-      data["datetime_type"] = self.datetime_type
+    if self._datetime_type is not None:
+      data["datetime_type"] = self._datetime_type
 
-    if self.unsigned_32 is not None:
-      data["unsigned_32"] = self.unsigned_32
+    if self._unsigned_32 is not None:
+      data["unsigned_32"] = self._unsigned_32
 
-    if self.unsigned_64 is not None:
-      data["unsigned_64"] = self.unsigned_64
+    if self._unsigned_64 is not None:
+      data["unsigned_64"] = self._unsigned_64
 
-    if self.signed_32 is not None:
-      data["signed_32"] = self.signed_32
+    if self._signed_32 is not None:
+      data["signed_32"] = self._signed_32
 
-    if self.signed_64 is not None:
-      data["signed_64"] = self.signed_64
+    if self._signed_64 is not None:
+      data["signed_64"] = self._signed_64
 
-    if self.float_type is not None:
-      data["float_type"] = self.float_type
+    if self._float_type is not None:
+      data["float_type"] = self._float_type
 
-    if self.double_type is not None:
-      data["double_type"] = self.double_type
+    if self._double_type is not None:
+      data["double_type"] = self._double_type
 
-    if self.bytes_type is not None:
-      data["bytes_type"] = self.bytes_type
+    if self._bytes_type is not None:
+      data["bytes_type"] = self._bytes_type
 
-    if self.any_type is not None:
-      data["any_type"] = self.any_type
+    if self._any_type is not None:
+      data["any_type"] = self._any_type
 
-    if self.array_type is not None:
-      data["array_type"] = [v.encode() for v in self.array_type]
+    if self._array_type is not None:
+      data["array_type"] = [v.encode() for v in self._array_type]
 
-    if self.array_of_array_type is not None:
-      data["array_of_array_type"] = [[v.encode() for v in v] for v in self.array_of_array_type]
+    if self._array_of_array_type is not None:
+      data["array_of_array_type"] = [[v.encode() for v in v] for v in self._array_of_array_type]
 
-    if self.map_type is not None:
-      data["map_type"] = dict((k, v.encode()) for (k, v) in self.map_type.items())
+    if self._map_type is not None:
+      data["map_type"] = dict((k, v.encode()) for (k, v) in self._map_type.items())
 
     return data
 
   def __repr__(self):
-    return "<Entry boolean_type:{!r}, string_type:{!r}, datetime_type:{!r}, unsigned_32:{!r}, unsigned_64:{!r}, signed_32:{!r}, signed_64:{!r}, float_type:{!r}, double_type:{!r}, bytes_type:{!r}, any_type:{!r}, array_type:{!r}, array_of_array_type:{!r}, map_type:{!r}>".format(self.boolean_type, self.string_type, self.datetime_type, self.unsigned_32, self.unsigned_64, self.signed_32, self.signed_64, self.float_type, self.double_type, self.bytes_type, self.any_type, self.array_type, self.array_of_array_type, self.map_type)
+    return "<Entry boolean_type:{!r}, string_type:{!r}, datetime_type:{!r}, unsigned_32:{!r}, unsigned_64:{!r}, signed_32:{!r}, signed_64:{!r}, float_type:{!r}, double_type:{!r}, bytes_type:{!r}, any_type:{!r}, array_type:{!r}, array_of_array_type:{!r}, map_type:{!r}>".format(self._boolean_type, self._string_type, self._datetime_type, self._unsigned_32, self._unsigned_64, self._signed_32, self._signed_64, self._float_type, self._double_type, self._bytes_type, self._any_type, self._array_type, self._array_of_array_type, self._map_type)

--- a/it/alltypes/structures/default/python3/test.py
+++ b/it/alltypes/structures/default/python3/test.py
@@ -1,61 +1,75 @@
 class Entry:
-  def __init__(self, boolean_type, string_type, datetime_type, unsigned_32, unsigned_64, signed_32, signed_64, float_type, double_type, bytes_type, any_type, array_type, array_of_array_type, map_type):
-    self.boolean_type = boolean_type
-    self.string_type = string_type
-    self.datetime_type = datetime_type
-    self.unsigned_32 = unsigned_32
-    self.unsigned_64 = unsigned_64
-    self.signed_32 = signed_32
-    self.signed_64 = signed_64
-    self.float_type = float_type
-    self.double_type = double_type
-    self.bytes_type = bytes_type
-    self.any_type = any_type
-    self.array_type = array_type
-    self.array_of_array_type = array_of_array_type
-    self.map_type = map_type
+  def __init__(self, _boolean_type, _string_type, _datetime_type, _unsigned_32, _unsigned_64, _signed_32, _signed_64, _float_type, _double_type, _bytes_type, _any_type, _array_type, _array_of_array_type, _map_type):
+    self._boolean_type = _boolean_type
+    self._string_type = _string_type
+    self._datetime_type = _datetime_type
+    self._unsigned_32 = _unsigned_32
+    self._unsigned_64 = _unsigned_64
+    self._signed_32 = _signed_32
+    self._signed_64 = _signed_64
+    self._float_type = _float_type
+    self._double_type = _double_type
+    self._bytes_type = _bytes_type
+    self._any_type = _any_type
+    self._array_type = _array_type
+    self._array_of_array_type = _array_of_array_type
+    self._map_type = _map_type
 
-  def get_boolean_type(self):
-    return self.boolean_type
+  @property
+  def boolean_type(self):
+    return self._boolean_type
 
-  def get_string_type(self):
-    return self.string_type
+  @property
+  def string_type(self):
+    return self._string_type
 
-  def get_datetime_type(self):
-    return self.datetime_type
+  @property
+  def datetime_type(self):
+    return self._datetime_type
 
-  def get_unsigned_32(self):
-    return self.unsigned_32
+  @property
+  def unsigned_32(self):
+    return self._unsigned_32
 
-  def get_unsigned_64(self):
-    return self.unsigned_64
+  @property
+  def unsigned_64(self):
+    return self._unsigned_64
 
-  def get_signed_32(self):
-    return self.signed_32
+  @property
+  def signed_32(self):
+    return self._signed_32
 
-  def get_signed_64(self):
-    return self.signed_64
+  @property
+  def signed_64(self):
+    return self._signed_64
 
-  def get_float_type(self):
-    return self.float_type
+  @property
+  def float_type(self):
+    return self._float_type
 
-  def get_double_type(self):
-    return self.double_type
+  @property
+  def double_type(self):
+    return self._double_type
 
-  def get_bytes_type(self):
-    return self.bytes_type
+  @property
+  def bytes_type(self):
+    return self._bytes_type
 
-  def get_any_type(self):
-    return self.any_type
+  @property
+  def any_type(self):
+    return self._any_type
 
-  def get_array_type(self):
-    return self.array_type
+  @property
+  def array_type(self):
+    return self._array_type
 
-  def get_array_of_array_type(self):
-    return self.array_of_array_type
+  @property
+  def array_of_array_type(self):
+    return self._array_of_array_type
 
-  def get_map_type(self):
-    return self.map_type
+  @property
+  def map_type(self):
+    return self._map_type
 
   @staticmethod
   def decode(data):
@@ -221,49 +235,49 @@ class Entry:
   def encode(self):
     data = dict()
 
-    if self.boolean_type is not None:
-      data["boolean_type"] = self.boolean_type
+    if self._boolean_type is not None:
+      data["boolean_type"] = self._boolean_type
 
-    if self.string_type is not None:
-      data["string_type"] = self.string_type
+    if self._string_type is not None:
+      data["string_type"] = self._string_type
 
-    if self.datetime_type is not None:
-      data["datetime_type"] = self.datetime_type
+    if self._datetime_type is not None:
+      data["datetime_type"] = self._datetime_type
 
-    if self.unsigned_32 is not None:
-      data["unsigned_32"] = self.unsigned_32
+    if self._unsigned_32 is not None:
+      data["unsigned_32"] = self._unsigned_32
 
-    if self.unsigned_64 is not None:
-      data["unsigned_64"] = self.unsigned_64
+    if self._unsigned_64 is not None:
+      data["unsigned_64"] = self._unsigned_64
 
-    if self.signed_32 is not None:
-      data["signed_32"] = self.signed_32
+    if self._signed_32 is not None:
+      data["signed_32"] = self._signed_32
 
-    if self.signed_64 is not None:
-      data["signed_64"] = self.signed_64
+    if self._signed_64 is not None:
+      data["signed_64"] = self._signed_64
 
-    if self.float_type is not None:
-      data["float_type"] = self.float_type
+    if self._float_type is not None:
+      data["float_type"] = self._float_type
 
-    if self.double_type is not None:
-      data["double_type"] = self.double_type
+    if self._double_type is not None:
+      data["double_type"] = self._double_type
 
-    if self.bytes_type is not None:
-      data["bytes_type"] = self.bytes_type
+    if self._bytes_type is not None:
+      data["bytes_type"] = self._bytes_type
 
-    if self.any_type is not None:
-      data["any_type"] = self.any_type
+    if self._any_type is not None:
+      data["any_type"] = self._any_type
 
-    if self.array_type is not None:
-      data["array_type"] = [v.encode() for v in self.array_type]
+    if self._array_type is not None:
+      data["array_type"] = [v.encode() for v in self._array_type]
 
-    if self.array_of_array_type is not None:
-      data["array_of_array_type"] = [[v.encode() for v in v] for v in self.array_of_array_type]
+    if self._array_of_array_type is not None:
+      data["array_of_array_type"] = [[v.encode() for v in v] for v in self._array_of_array_type]
 
-    if self.map_type is not None:
-      data["map_type"] = dict((k, v.encode()) for (k, v) in self.map_type.items())
+    if self._map_type is not None:
+      data["map_type"] = dict((k, v.encode()) for (k, v) in self._map_type.items())
 
     return data
 
   def __repr__(self):
-    return "<Entry boolean_type:{!r}, string_type:{!r}, datetime_type:{!r}, unsigned_32:{!r}, unsigned_64:{!r}, signed_32:{!r}, signed_64:{!r}, float_type:{!r}, double_type:{!r}, bytes_type:{!r}, any_type:{!r}, array_type:{!r}, array_of_array_type:{!r}, map_type:{!r}>".format(self.boolean_type, self.string_type, self.datetime_type, self.unsigned_32, self.unsigned_64, self.signed_32, self.signed_64, self.float_type, self.double_type, self.bytes_type, self.any_type, self.array_type, self.array_of_array_type, self.map_type)
+    return "<Entry boolean_type:{!r}, string_type:{!r}, datetime_type:{!r}, unsigned_32:{!r}, unsigned_64:{!r}, signed_32:{!r}, signed_64:{!r}, float_type:{!r}, double_type:{!r}, bytes_type:{!r}, any_type:{!r}, array_type:{!r}, array_of_array_type:{!r}, map_type:{!r}>".format(self._boolean_type, self._string_type, self._datetime_type, self._unsigned_32, self._unsigned_64, self._signed_32, self._signed_64, self._float_type, self._double_type, self._bytes_type, self._any_type, self._array_type, self._array_of_array_type, self._map_type)

--- a/it/basic/structures/default/python/test.py
+++ b/it/basic/structures/default/python/test.py
@@ -1,12 +1,13 @@
 class Entry:
-  def __init__(self, foo):
-    self.foo = foo
+  def __init__(self, _foo):
+    self._foo = _foo
 
-  def get_foo(self):
+  @property
+  def foo(self):
     """
     The foo field.
     """
-    return self.foo
+    return self._foo
 
   @staticmethod
   def decode(data):
@@ -23,23 +24,24 @@ class Entry:
   def encode(self):
     data = dict()
 
-    if self.foo is not None:
-      data["foo"] = self.foo.encode()
+    if self._foo is not None:
+      data["foo"] = self._foo.encode()
 
     return data
 
   def __repr__(self):
-    return "<Entry foo:{!r}>".format(self.foo)
+    return "<Entry foo:{!r}>".format(self._foo)
 
 class Foo:
-  def __init__(self, field):
-    self.field = field
+  def __init__(self, _field):
+    self._field = _field
 
-  def get_field(self):
+  @property
+  def field(self):
     """
     The field.
     """
-    return self.field
+    return self._field
 
   @staticmethod
   def decode(data):
@@ -53,25 +55,26 @@ class Foo:
   def encode(self):
     data = dict()
 
-    if self.field is None:
+    if self._field is None:
       raise Exception("field: is a required field")
 
-    data["field"] = self.field
+    data["field"] = self._field
 
     return data
 
   def __repr__(self):
-    return "<Foo field:{!r}>".format(self.field)
+    return "<Foo field:{!r}>".format(self._field)
 
 class Bar:
-  def __init__(self, field):
-    self.field = field
+  def __init__(self, _field):
+    self._field = _field
 
-  def get_field(self):
+  @property
+  def field(self):
     """
     The inner field.
     """
-    return self.field
+    return self._field
 
   @staticmethod
   def decode(data):
@@ -84,25 +87,26 @@ class Bar:
   def encode(self):
     data = dict()
 
-    if self.field is None:
+    if self._field is None:
       raise Exception("field: is a required field")
 
-    data["field"] = self.field.encode()
+    data["field"] = self._field.encode()
 
     return data
 
   def __repr__(self):
-    return "<Bar field:{!r}>".format(self.field)
+    return "<Bar field:{!r}>".format(self._field)
 
 class Bar_Inner:
-  def __init__(self, field):
-    self.field = field
+  def __init__(self, _field):
+    self._field = _field
 
-  def get_field(self):
+  @property
+  def field(self):
     """
     The field.
     """
-    return self.field
+    return self._field
 
   @staticmethod
   def decode(data):
@@ -116,12 +120,12 @@ class Bar_Inner:
   def encode(self):
     data = dict()
 
-    if self.field is None:
+    if self._field is None:
       raise Exception("field: is a required field")
 
-    data["field"] = self.field
+    data["field"] = self._field
 
     return data
 
   def __repr__(self):
-    return "<Bar_Inner field:{!r}>".format(self.field)
+    return "<Bar_Inner field:{!r}>".format(self._field)

--- a/it/basic/structures/default/python3/test.py
+++ b/it/basic/structures/default/python3/test.py
@@ -1,12 +1,13 @@
 class Entry:
-  def __init__(self, foo):
-    self.foo = foo
+  def __init__(self, _foo):
+    self._foo = _foo
 
-  def get_foo(self):
+  @property
+  def foo(self):
     """
     The foo field.
     """
-    return self.foo
+    return self._foo
 
   @staticmethod
   def decode(data):
@@ -23,23 +24,24 @@ class Entry:
   def encode(self):
     data = dict()
 
-    if self.foo is not None:
-      data["foo"] = self.foo.encode()
+    if self._foo is not None:
+      data["foo"] = self._foo.encode()
 
     return data
 
   def __repr__(self):
-    return "<Entry foo:{!r}>".format(self.foo)
+    return "<Entry foo:{!r}>".format(self._foo)
 
 class Foo:
-  def __init__(self, field):
-    self.field = field
+  def __init__(self, _field):
+    self._field = _field
 
-  def get_field(self):
+  @property
+  def field(self):
     """
     The field.
     """
-    return self.field
+    return self._field
 
   @staticmethod
   def decode(data):
@@ -53,25 +55,26 @@ class Foo:
   def encode(self):
     data = dict()
 
-    if self.field is None:
+    if self._field is None:
       raise Exception("field: is a required field")
 
-    data["field"] = self.field
+    data["field"] = self._field
 
     return data
 
   def __repr__(self):
-    return "<Foo field:{!r}>".format(self.field)
+    return "<Foo field:{!r}>".format(self._field)
 
 class Bar:
-  def __init__(self, field):
-    self.field = field
+  def __init__(self, _field):
+    self._field = _field
 
-  def get_field(self):
+  @property
+  def field(self):
     """
     The inner field.
     """
-    return self.field
+    return self._field
 
   @staticmethod
   def decode(data):
@@ -84,25 +87,26 @@ class Bar:
   def encode(self):
     data = dict()
 
-    if self.field is None:
+    if self._field is None:
       raise Exception("field: is a required field")
 
-    data["field"] = self.field.encode()
+    data["field"] = self._field.encode()
 
     return data
 
   def __repr__(self):
-    return "<Bar field:{!r}>".format(self.field)
+    return "<Bar field:{!r}>".format(self._field)
 
 class Bar_Inner:
-  def __init__(self, field):
-    self.field = field
+  def __init__(self, _field):
+    self._field = _field
 
-  def get_field(self):
+  @property
+  def field(self):
     """
     The field.
     """
-    return self.field
+    return self._field
 
   @staticmethod
   def decode(data):
@@ -116,12 +120,12 @@ class Bar_Inner:
   def encode(self):
     data = dict()
 
-    if self.field is None:
+    if self._field is None:
       raise Exception("field: is a required field")
 
-    data["field"] = self.field
+    data["field"] = self._field
 
     return data
 
   def __repr__(self):
-    return "<Bar_Inner field:{!r}>".format(self.field)
+    return "<Bar_Inner field:{!r}>".format(self._field)

--- a/it/code/structures/default/python/test.py
+++ b/it/code/structures/default/python/test.py
@@ -72,28 +72,29 @@ class Interface_SubType:
     pass
 
 class Enum:
-  def __init__(self, ordinal):
-    self.ordinal = ordinal
+  def __init__(self, _ordinal):
+    self._ordinal = _ordinal
 
-  def get_ordinal(self):
-    return self.ordinal
+  @property
+  def ordinal(self):
+    return self._ordinal
 
   def enum_method(self):
     pass
 
   def encode(self):
-    return self.ordinal
+    return self._ordinal
 
   @classmethod
   def decode(cls, data):
     for value in cls.__members__.values():
-      if value.ordinal == data:
+      if value._ordinal == data:
         return value
 
     raise Exception("data does not match enum")
 
   def __repr__(self):
-    return "<Enum ordinal:{!r}>".format(self.ordinal)
+    return "<Enum ordinal:{!r}>".format(self._ordinal)
 
 class Tuple:
   def __init__(self):

--- a/it/code/structures/default/python3/test.py
+++ b/it/code/structures/default/python3/test.py
@@ -72,28 +72,29 @@ class Interface_SubType:
     pass
 
 class Enum:
-  def __init__(self, ordinal):
-    self.ordinal = ordinal
+  def __init__(self, _ordinal):
+    self._ordinal = _ordinal
 
-  def get_ordinal(self):
-    return self.ordinal
+  @property
+  def ordinal(self):
+    return self._ordinal
 
   def enum_method(self):
     pass
 
   def encode(self):
-    return self.ordinal
+    return self._ordinal
 
   @classmethod
   def decode(cls, data):
     for value in cls.__members__.values():
-      if value.ordinal == data:
+      if value._ordinal == data:
         return value
 
     raise Exception("data does not match enum")
 
   def __repr__(self):
-    return "<Enum ordinal:{!r}>".format(self.ordinal)
+    return "<Enum ordinal:{!r}>".format(self._ordinal)
 
 class Tuple:
   def __init__(self):

--- a/it/default_naming/structures/default/python/lower_camel.py
+++ b/it/default_naming/structures/default/python/lower_camel.py
@@ -1,9 +1,10 @@
 class Value:
-  def __init__(self, foo_bar):
-    self.foo_bar = foo_bar
+  def __init__(self, _foo_bar):
+    self._foo_bar = _foo_bar
 
-  def get_foo_bar(self):
-    return self.foo_bar
+  @property
+  def foo_bar(self):
+    return self._foo_bar
 
   @staticmethod
   def decode(data):
@@ -17,13 +18,13 @@ class Value:
   def encode(self):
     data = dict()
 
-    if self.foo_bar is None:
+    if self._foo_bar is None:
       raise Exception("fooBar: is a required field")
 
-    data["fooBar"] = self.foo_bar
+    data["fooBar"] = self._foo_bar
 
     return data
 
   def __repr__(self):
-    return "<Value foo_bar:{!r}>".format(self.foo_bar)
+    return "<Value foo_bar:{!r}>".format(self._foo_bar)
 

--- a/it/default_naming/structures/default/python/lower_snake.py
+++ b/it/default_naming/structures/default/python/lower_snake.py
@@ -1,9 +1,10 @@
 class Value:
-  def __init__(self, foo_bar):
-    self.foo_bar = foo_bar
+  def __init__(self, _foo_bar):
+    self._foo_bar = _foo_bar
 
-  def get_foo_bar(self):
-    return self.foo_bar
+  @property
+  def foo_bar(self):
+    return self._foo_bar
 
   @staticmethod
   def decode(data):
@@ -17,13 +18,13 @@ class Value:
   def encode(self):
     data = dict()
 
-    if self.foo_bar is None:
+    if self._foo_bar is None:
       raise Exception("foo_bar: is a required field")
 
-    data["foo_bar"] = self.foo_bar
+    data["foo_bar"] = self._foo_bar
 
     return data
 
   def __repr__(self):
-    return "<Value foo_bar:{!r}>".format(self.foo_bar)
+    return "<Value foo_bar:{!r}>".format(self._foo_bar)
 

--- a/it/default_naming/structures/default/python/test.py
+++ b/it/default_naming/structures/default/python/test.py
@@ -4,23 +4,27 @@ import upper_camel as upper_camel
 import upper_snake as upper_snake
 
 class Entry:
-  def __init__(self, lower_camel, lower_snake, upper_camel, upper_snake):
-    self.lower_camel = lower_camel
-    self.lower_snake = lower_snake
-    self.upper_camel = upper_camel
-    self.upper_snake = upper_snake
+  def __init__(self, _lower_camel, _lower_snake, _upper_camel, _upper_snake):
+    self._lower_camel = _lower_camel
+    self._lower_snake = _lower_snake
+    self._upper_camel = _upper_camel
+    self._upper_snake = _upper_snake
 
-  def get_lower_camel(self):
-    return self.lower_camel
+  @property
+  def lower_camel(self):
+    return self._lower_camel
 
-  def get_lower_snake(self):
-    return self.lower_snake
+  @property
+  def lower_snake(self):
+    return self._lower_snake
 
-  def get_upper_camel(self):
-    return self.upper_camel
+  @property
+  def upper_camel(self):
+    return self._upper_camel
 
-  def get_upper_snake(self):
-    return self.upper_snake
+  @property
+  def upper_snake(self):
+    return self._upper_snake
 
   @staticmethod
   def decode(data):
@@ -61,19 +65,19 @@ class Entry:
   def encode(self):
     data = dict()
 
-    if self.lower_camel is not None:
-      data["lower_camel"] = self.lower_camel.encode()
+    if self._lower_camel is not None:
+      data["lower_camel"] = self._lower_camel.encode()
 
-    if self.lower_snake is not None:
-      data["lower_snake"] = self.lower_snake.encode()
+    if self._lower_snake is not None:
+      data["lower_snake"] = self._lower_snake.encode()
 
-    if self.upper_camel is not None:
-      data["upper_camel"] = self.upper_camel.encode()
+    if self._upper_camel is not None:
+      data["upper_camel"] = self._upper_camel.encode()
 
-    if self.upper_snake is not None:
-      data["upper_snake"] = self.upper_snake.encode()
+    if self._upper_snake is not None:
+      data["upper_snake"] = self._upper_snake.encode()
 
     return data
 
   def __repr__(self):
-    return "<Entry lower_camel:{!r}, lower_snake:{!r}, upper_camel:{!r}, upper_snake:{!r}>".format(self.lower_camel, self.lower_snake, self.upper_camel, self.upper_snake)
+    return "<Entry lower_camel:{!r}, lower_snake:{!r}, upper_camel:{!r}, upper_snake:{!r}>".format(self._lower_camel, self._lower_snake, self._upper_camel, self._upper_snake)

--- a/it/default_naming/structures/default/python/upper_camel.py
+++ b/it/default_naming/structures/default/python/upper_camel.py
@@ -1,9 +1,10 @@
 class Value:
-  def __init__(self, foo_bar):
-    self.foo_bar = foo_bar
+  def __init__(self, _foo_bar):
+    self._foo_bar = _foo_bar
 
-  def get_foo_bar(self):
-    return self.foo_bar
+  @property
+  def foo_bar(self):
+    return self._foo_bar
 
   @staticmethod
   def decode(data):
@@ -17,13 +18,13 @@ class Value:
   def encode(self):
     data = dict()
 
-    if self.foo_bar is None:
+    if self._foo_bar is None:
       raise Exception("FooBar: is a required field")
 
-    data["FooBar"] = self.foo_bar
+    data["FooBar"] = self._foo_bar
 
     return data
 
   def __repr__(self):
-    return "<Value foo_bar:{!r}>".format(self.foo_bar)
+    return "<Value foo_bar:{!r}>".format(self._foo_bar)
 

--- a/it/default_naming/structures/default/python/upper_snake.py
+++ b/it/default_naming/structures/default/python/upper_snake.py
@@ -1,9 +1,10 @@
 class Value:
-  def __init__(self, foo_bar):
-    self.foo_bar = foo_bar
+  def __init__(self, _foo_bar):
+    self._foo_bar = _foo_bar
 
-  def get_foo_bar(self):
-    return self.foo_bar
+  @property
+  def foo_bar(self):
+    return self._foo_bar
 
   @staticmethod
   def decode(data):
@@ -17,13 +18,13 @@ class Value:
   def encode(self):
     data = dict()
 
-    if self.foo_bar is None:
+    if self._foo_bar is None:
       raise Exception("FOO_BAR: is a required field")
 
-    data["FOO_BAR"] = self.foo_bar
+    data["FOO_BAR"] = self._foo_bar
 
     return data
 
   def __repr__(self):
-    return "<Value foo_bar:{!r}>".format(self.foo_bar)
+    return "<Value foo_bar:{!r}>".format(self._foo_bar)
 

--- a/it/default_naming/structures/default/python3/lower_camel.py
+++ b/it/default_naming/structures/default/python3/lower_camel.py
@@ -1,9 +1,10 @@
 class Value:
-  def __init__(self, foo_bar):
-    self.foo_bar = foo_bar
+  def __init__(self, _foo_bar):
+    self._foo_bar = _foo_bar
 
-  def get_foo_bar(self):
-    return self.foo_bar
+  @property
+  def foo_bar(self):
+    return self._foo_bar
 
   @staticmethod
   def decode(data):
@@ -17,13 +18,13 @@ class Value:
   def encode(self):
     data = dict()
 
-    if self.foo_bar is None:
+    if self._foo_bar is None:
       raise Exception("fooBar: is a required field")
 
-    data["fooBar"] = self.foo_bar
+    data["fooBar"] = self._foo_bar
 
     return data
 
   def __repr__(self):
-    return "<Value foo_bar:{!r}>".format(self.foo_bar)
+    return "<Value foo_bar:{!r}>".format(self._foo_bar)
 

--- a/it/default_naming/structures/default/python3/lower_snake.py
+++ b/it/default_naming/structures/default/python3/lower_snake.py
@@ -1,9 +1,10 @@
 class Value:
-  def __init__(self, foo_bar):
-    self.foo_bar = foo_bar
+  def __init__(self, _foo_bar):
+    self._foo_bar = _foo_bar
 
-  def get_foo_bar(self):
-    return self.foo_bar
+  @property
+  def foo_bar(self):
+    return self._foo_bar
 
   @staticmethod
   def decode(data):
@@ -17,13 +18,13 @@ class Value:
   def encode(self):
     data = dict()
 
-    if self.foo_bar is None:
+    if self._foo_bar is None:
       raise Exception("foo_bar: is a required field")
 
-    data["foo_bar"] = self.foo_bar
+    data["foo_bar"] = self._foo_bar
 
     return data
 
   def __repr__(self):
-    return "<Value foo_bar:{!r}>".format(self.foo_bar)
+    return "<Value foo_bar:{!r}>".format(self._foo_bar)
 

--- a/it/default_naming/structures/default/python3/test.py
+++ b/it/default_naming/structures/default/python3/test.py
@@ -4,23 +4,27 @@ import upper_camel as upper_camel
 import upper_snake as upper_snake
 
 class Entry:
-  def __init__(self, lower_camel, lower_snake, upper_camel, upper_snake):
-    self.lower_camel = lower_camel
-    self.lower_snake = lower_snake
-    self.upper_camel = upper_camel
-    self.upper_snake = upper_snake
+  def __init__(self, _lower_camel, _lower_snake, _upper_camel, _upper_snake):
+    self._lower_camel = _lower_camel
+    self._lower_snake = _lower_snake
+    self._upper_camel = _upper_camel
+    self._upper_snake = _upper_snake
 
-  def get_lower_camel(self):
-    return self.lower_camel
+  @property
+  def lower_camel(self):
+    return self._lower_camel
 
-  def get_lower_snake(self):
-    return self.lower_snake
+  @property
+  def lower_snake(self):
+    return self._lower_snake
 
-  def get_upper_camel(self):
-    return self.upper_camel
+  @property
+  def upper_camel(self):
+    return self._upper_camel
 
-  def get_upper_snake(self):
-    return self.upper_snake
+  @property
+  def upper_snake(self):
+    return self._upper_snake
 
   @staticmethod
   def decode(data):
@@ -61,19 +65,19 @@ class Entry:
   def encode(self):
     data = dict()
 
-    if self.lower_camel is not None:
-      data["lower_camel"] = self.lower_camel.encode()
+    if self._lower_camel is not None:
+      data["lower_camel"] = self._lower_camel.encode()
 
-    if self.lower_snake is not None:
-      data["lower_snake"] = self.lower_snake.encode()
+    if self._lower_snake is not None:
+      data["lower_snake"] = self._lower_snake.encode()
 
-    if self.upper_camel is not None:
-      data["upper_camel"] = self.upper_camel.encode()
+    if self._upper_camel is not None:
+      data["upper_camel"] = self._upper_camel.encode()
 
-    if self.upper_snake is not None:
-      data["upper_snake"] = self.upper_snake.encode()
+    if self._upper_snake is not None:
+      data["upper_snake"] = self._upper_snake.encode()
 
     return data
 
   def __repr__(self):
-    return "<Entry lower_camel:{!r}, lower_snake:{!r}, upper_camel:{!r}, upper_snake:{!r}>".format(self.lower_camel, self.lower_snake, self.upper_camel, self.upper_snake)
+    return "<Entry lower_camel:{!r}, lower_snake:{!r}, upper_camel:{!r}, upper_snake:{!r}>".format(self._lower_camel, self._lower_snake, self._upper_camel, self._upper_snake)

--- a/it/default_naming/structures/default/python3/upper_camel.py
+++ b/it/default_naming/structures/default/python3/upper_camel.py
@@ -1,9 +1,10 @@
 class Value:
-  def __init__(self, foo_bar):
-    self.foo_bar = foo_bar
+  def __init__(self, _foo_bar):
+    self._foo_bar = _foo_bar
 
-  def get_foo_bar(self):
-    return self.foo_bar
+  @property
+  def foo_bar(self):
+    return self._foo_bar
 
   @staticmethod
   def decode(data):
@@ -17,13 +18,13 @@ class Value:
   def encode(self):
     data = dict()
 
-    if self.foo_bar is None:
+    if self._foo_bar is None:
       raise Exception("FooBar: is a required field")
 
-    data["FooBar"] = self.foo_bar
+    data["FooBar"] = self._foo_bar
 
     return data
 
   def __repr__(self):
-    return "<Value foo_bar:{!r}>".format(self.foo_bar)
+    return "<Value foo_bar:{!r}>".format(self._foo_bar)
 

--- a/it/default_naming/structures/default/python3/upper_snake.py
+++ b/it/default_naming/structures/default/python3/upper_snake.py
@@ -1,9 +1,10 @@
 class Value:
-  def __init__(self, foo_bar):
-    self.foo_bar = foo_bar
+  def __init__(self, _foo_bar):
+    self._foo_bar = _foo_bar
 
-  def get_foo_bar(self):
-    return self.foo_bar
+  @property
+  def foo_bar(self):
+    return self._foo_bar
 
   @staticmethod
   def decode(data):
@@ -17,13 +18,13 @@ class Value:
   def encode(self):
     data = dict()
 
-    if self.foo_bar is None:
+    if self._foo_bar is None:
       raise Exception("FOO_BAR: is a required field")
 
-    data["FOO_BAR"] = self.foo_bar
+    data["FOO_BAR"] = self._foo_bar
 
     return data
 
   def __repr__(self):
-    return "<Value foo_bar:{!r}>".format(self.foo_bar)
+    return "<Value foo_bar:{!r}>".format(self._foo_bar)
 

--- a/it/enum/structures/default/python/test.py
+++ b/it/enum/structures/default/python/test.py
@@ -1,31 +1,37 @@
 import enum
 
 class Entry:
-  def __init__(self, explicit, implicit, enum_u32, enum_u64, enum_i32, enum_i64):
-    self.explicit = explicit
-    self.implicit = implicit
-    self.enum_u32 = enum_u32
-    self.enum_u64 = enum_u64
-    self.enum_i32 = enum_i32
-    self.enum_i64 = enum_i64
+  def __init__(self, _explicit, _implicit, _enum_u32, _enum_u64, _enum_i32, _enum_i64):
+    self._explicit = _explicit
+    self._implicit = _implicit
+    self._enum_u32 = _enum_u32
+    self._enum_u64 = _enum_u64
+    self._enum_i32 = _enum_i32
+    self._enum_i64 = _enum_i64
 
-  def get_explicit(self):
-    return self.explicit
+  @property
+  def explicit(self):
+    return self._explicit
 
-  def get_implicit(self):
-    return self.implicit
+  @property
+  def implicit(self):
+    return self._implicit
 
-  def get_enum_u32(self):
-    return self.enum_u32
+  @property
+  def enum_u32(self):
+    return self._enum_u32
 
-  def get_enum_u64(self):
-    return self.enum_u64
+  @property
+  def enum_u64(self):
+    return self._enum_u64
 
-  def get_enum_i32(self):
-    return self.enum_i32
+  @property
+  def enum_i32(self):
+    return self._enum_i32
 
-  def get_enum_i64(self):
-    return self.enum_i64
+  @property
+  def enum_i64(self):
+    return self._enum_i64
 
   @staticmethod
   def decode(data):
@@ -82,175 +88,182 @@ class Entry:
   def encode(self):
     data = dict()
 
-    if self.explicit is not None:
-      data["explicit"] = self.explicit.encode()
+    if self._explicit is not None:
+      data["explicit"] = self._explicit.encode()
 
-    if self.implicit is not None:
-      data["implicit"] = self.implicit.encode()
+    if self._implicit is not None:
+      data["implicit"] = self._implicit.encode()
 
-    if self.enum_u32 is not None:
-      data["enum_u32"] = self.enum_u32.encode()
+    if self._enum_u32 is not None:
+      data["enum_u32"] = self._enum_u32.encode()
 
-    if self.enum_u64 is not None:
-      data["enum_u64"] = self.enum_u64.encode()
+    if self._enum_u64 is not None:
+      data["enum_u64"] = self._enum_u64.encode()
 
-    if self.enum_i32 is not None:
-      data["enum_i32"] = self.enum_i32.encode()
+    if self._enum_i32 is not None:
+      data["enum_i32"] = self._enum_i32.encode()
 
-    if self.enum_i64 is not None:
-      data["enum_i64"] = self.enum_i64.encode()
+    if self._enum_i64 is not None:
+      data["enum_i64"] = self._enum_i64.encode()
 
     return data
 
   def __repr__(self):
-    return "<Entry explicit:{!r}, implicit:{!r}, enum_u32:{!r}, enum_u64:{!r}, enum_i32:{!r}, enum_i64:{!r}>".format(self.explicit, self.implicit, self.enum_u32, self.enum_u64, self.enum_i32, self.enum_i64)
+    return "<Entry explicit:{!r}, implicit:{!r}, enum_u32:{!r}, enum_u64:{!r}, enum_i32:{!r}, enum_i64:{!r}>".format(self._explicit, self._implicit, self._enum_u32, self._enum_u64, self._enum_i32, self._enum_i64)
 
 class EnumExplicit:
-  def __init__(self, ordinal):
-    self.ordinal = ordinal
+  def __init__(self, _ordinal):
+    self._ordinal = _ordinal
 
-  def get_ordinal(self):
-    return self.ordinal
+  @property
+  def ordinal(self):
+    return self._ordinal
 
   def encode(self):
-    return self.ordinal
+    return self._ordinal
 
   @classmethod
   def decode(cls, data):
     for value in cls.__members__.values():
-      if value.ordinal == data:
+      if value._ordinal == data:
         return value
 
     raise Exception("data does not match enum")
 
   def __repr__(self):
-    return "<EnumExplicit ordinal:{!r}>".format(self.ordinal)
+    return "<EnumExplicit ordinal:{!r}>".format(self._ordinal)
 
 class EnumImplicit:
-  def __init__(self, ordinal):
-    self.ordinal = ordinal
+  def __init__(self, _ordinal):
+    self._ordinal = _ordinal
 
-  def get_ordinal(self):
-    return self.ordinal
+  @property
+  def ordinal(self):
+    return self._ordinal
 
   def encode(self):
-    return self.ordinal
+    return self._ordinal
 
   @classmethod
   def decode(cls, data):
     for value in cls.__members__.values():
-      if value.ordinal == data:
+      if value._ordinal == data:
         return value
 
     raise Exception("data does not match enum")
 
   def __repr__(self):
-    return "<EnumImplicit ordinal:{!r}>".format(self.ordinal)
+    return "<EnumImplicit ordinal:{!r}>".format(self._ordinal)
 
 class EnumLongNames:
-  def __init__(self, ordinal):
-    self.ordinal = ordinal
+  def __init__(self, _ordinal):
+    self._ordinal = _ordinal
 
-  def get_ordinal(self):
-    return self.ordinal
+  @property
+  def ordinal(self):
+    return self._ordinal
 
   def encode(self):
-    return self.ordinal
+    return self._ordinal
 
   @classmethod
   def decode(cls, data):
     for value in cls.__members__.values():
-      if value.ordinal == data:
+      if value._ordinal == data:
         return value
 
     raise Exception("data does not match enum")
 
   def __repr__(self):
-    return "<EnumLongNames ordinal:{!r}>".format(self.ordinal)
+    return "<EnumLongNames ordinal:{!r}>".format(self._ordinal)
 
 class EnumU32:
-  def __init__(self, ordinal):
-    self.ordinal = ordinal
+  def __init__(self, _ordinal):
+    self._ordinal = _ordinal
 
-  def get_ordinal(self):
-    return self.ordinal
+  @property
+  def ordinal(self):
+    return self._ordinal
 
   def encode(self):
-    return self.ordinal
+    return self._ordinal
 
   @classmethod
   def decode(cls, data):
     for value in cls.__members__.values():
-      if value.ordinal == data:
+      if value._ordinal == data:
         return value
 
     raise Exception("data does not match enum")
 
   def __repr__(self):
-    return "<EnumU32 ordinal:{!r}>".format(self.ordinal)
+    return "<EnumU32 ordinal:{!r}>".format(self._ordinal)
 
 class EnumU64:
-  def __init__(self, ordinal):
-    self.ordinal = ordinal
+  def __init__(self, _ordinal):
+    self._ordinal = _ordinal
 
-  def get_ordinal(self):
-    return self.ordinal
+  @property
+  def ordinal(self):
+    return self._ordinal
 
   def encode(self):
-    return self.ordinal
+    return self._ordinal
 
   @classmethod
   def decode(cls, data):
     for value in cls.__members__.values():
-      if value.ordinal == data:
+      if value._ordinal == data:
         return value
 
     raise Exception("data does not match enum")
 
   def __repr__(self):
-    return "<EnumU64 ordinal:{!r}>".format(self.ordinal)
+    return "<EnumU64 ordinal:{!r}>".format(self._ordinal)
 
 class EnumI32:
-  def __init__(self, ordinal):
-    self.ordinal = ordinal
+  def __init__(self, _ordinal):
+    self._ordinal = _ordinal
 
-  def get_ordinal(self):
-    return self.ordinal
+  @property
+  def ordinal(self):
+    return self._ordinal
 
   def encode(self):
-    return self.ordinal
+    return self._ordinal
 
   @classmethod
   def decode(cls, data):
     for value in cls.__members__.values():
-      if value.ordinal == data:
+      if value._ordinal == data:
         return value
 
     raise Exception("data does not match enum")
 
   def __repr__(self):
-    return "<EnumI32 ordinal:{!r}>".format(self.ordinal)
+    return "<EnumI32 ordinal:{!r}>".format(self._ordinal)
 
 class EnumI64:
-  def __init__(self, ordinal):
-    self.ordinal = ordinal
+  def __init__(self, _ordinal):
+    self._ordinal = _ordinal
 
-  def get_ordinal(self):
-    return self.ordinal
+  @property
+  def ordinal(self):
+    return self._ordinal
 
   def encode(self):
-    return self.ordinal
+    return self._ordinal
 
   @classmethod
   def decode(cls, data):
     for value in cls.__members__.values():
-      if value.ordinal == data:
+      if value._ordinal == data:
         return value
 
     raise Exception("data does not match enum")
 
   def __repr__(self):
-    return "<EnumI64 ordinal:{!r}>".format(self.ordinal)
+    return "<EnumI64 ordinal:{!r}>".format(self._ordinal)
 
 EnumExplicit = enum.Enum("EnumExplicit", [("A", "foo"), ("B", "bar")], type=EnumExplicit)
 

--- a/it/enum/structures/default/python3/test.py
+++ b/it/enum/structures/default/python3/test.py
@@ -1,31 +1,37 @@
 import enum
 
 class Entry:
-  def __init__(self, explicit, implicit, enum_u32, enum_u64, enum_i32, enum_i64):
-    self.explicit = explicit
-    self.implicit = implicit
-    self.enum_u32 = enum_u32
-    self.enum_u64 = enum_u64
-    self.enum_i32 = enum_i32
-    self.enum_i64 = enum_i64
+  def __init__(self, _explicit, _implicit, _enum_u32, _enum_u64, _enum_i32, _enum_i64):
+    self._explicit = _explicit
+    self._implicit = _implicit
+    self._enum_u32 = _enum_u32
+    self._enum_u64 = _enum_u64
+    self._enum_i32 = _enum_i32
+    self._enum_i64 = _enum_i64
 
-  def get_explicit(self):
-    return self.explicit
+  @property
+  def explicit(self):
+    return self._explicit
 
-  def get_implicit(self):
-    return self.implicit
+  @property
+  def implicit(self):
+    return self._implicit
 
-  def get_enum_u32(self):
-    return self.enum_u32
+  @property
+  def enum_u32(self):
+    return self._enum_u32
 
-  def get_enum_u64(self):
-    return self.enum_u64
+  @property
+  def enum_u64(self):
+    return self._enum_u64
 
-  def get_enum_i32(self):
-    return self.enum_i32
+  @property
+  def enum_i32(self):
+    return self._enum_i32
 
-  def get_enum_i64(self):
-    return self.enum_i64
+  @property
+  def enum_i64(self):
+    return self._enum_i64
 
   @staticmethod
   def decode(data):
@@ -82,175 +88,182 @@ class Entry:
   def encode(self):
     data = dict()
 
-    if self.explicit is not None:
-      data["explicit"] = self.explicit.encode()
+    if self._explicit is not None:
+      data["explicit"] = self._explicit.encode()
 
-    if self.implicit is not None:
-      data["implicit"] = self.implicit.encode()
+    if self._implicit is not None:
+      data["implicit"] = self._implicit.encode()
 
-    if self.enum_u32 is not None:
-      data["enum_u32"] = self.enum_u32.encode()
+    if self._enum_u32 is not None:
+      data["enum_u32"] = self._enum_u32.encode()
 
-    if self.enum_u64 is not None:
-      data["enum_u64"] = self.enum_u64.encode()
+    if self._enum_u64 is not None:
+      data["enum_u64"] = self._enum_u64.encode()
 
-    if self.enum_i32 is not None:
-      data["enum_i32"] = self.enum_i32.encode()
+    if self._enum_i32 is not None:
+      data["enum_i32"] = self._enum_i32.encode()
 
-    if self.enum_i64 is not None:
-      data["enum_i64"] = self.enum_i64.encode()
+    if self._enum_i64 is not None:
+      data["enum_i64"] = self._enum_i64.encode()
 
     return data
 
   def __repr__(self):
-    return "<Entry explicit:{!r}, implicit:{!r}, enum_u32:{!r}, enum_u64:{!r}, enum_i32:{!r}, enum_i64:{!r}>".format(self.explicit, self.implicit, self.enum_u32, self.enum_u64, self.enum_i32, self.enum_i64)
+    return "<Entry explicit:{!r}, implicit:{!r}, enum_u32:{!r}, enum_u64:{!r}, enum_i32:{!r}, enum_i64:{!r}>".format(self._explicit, self._implicit, self._enum_u32, self._enum_u64, self._enum_i32, self._enum_i64)
 
 class EnumExplicit:
-  def __init__(self, ordinal):
-    self.ordinal = ordinal
+  def __init__(self, _ordinal):
+    self._ordinal = _ordinal
 
-  def get_ordinal(self):
-    return self.ordinal
+  @property
+  def ordinal(self):
+    return self._ordinal
 
   def encode(self):
-    return self.ordinal
+    return self._ordinal
 
   @classmethod
   def decode(cls, data):
     for value in cls.__members__.values():
-      if value.ordinal == data:
+      if value._ordinal == data:
         return value
 
     raise Exception("data does not match enum")
 
   def __repr__(self):
-    return "<EnumExplicit ordinal:{!r}>".format(self.ordinal)
+    return "<EnumExplicit ordinal:{!r}>".format(self._ordinal)
 
 class EnumImplicit:
-  def __init__(self, ordinal):
-    self.ordinal = ordinal
+  def __init__(self, _ordinal):
+    self._ordinal = _ordinal
 
-  def get_ordinal(self):
-    return self.ordinal
+  @property
+  def ordinal(self):
+    return self._ordinal
 
   def encode(self):
-    return self.ordinal
+    return self._ordinal
 
   @classmethod
   def decode(cls, data):
     for value in cls.__members__.values():
-      if value.ordinal == data:
+      if value._ordinal == data:
         return value
 
     raise Exception("data does not match enum")
 
   def __repr__(self):
-    return "<EnumImplicit ordinal:{!r}>".format(self.ordinal)
+    return "<EnumImplicit ordinal:{!r}>".format(self._ordinal)
 
 class EnumLongNames:
-  def __init__(self, ordinal):
-    self.ordinal = ordinal
+  def __init__(self, _ordinal):
+    self._ordinal = _ordinal
 
-  def get_ordinal(self):
-    return self.ordinal
+  @property
+  def ordinal(self):
+    return self._ordinal
 
   def encode(self):
-    return self.ordinal
+    return self._ordinal
 
   @classmethod
   def decode(cls, data):
     for value in cls.__members__.values():
-      if value.ordinal == data:
+      if value._ordinal == data:
         return value
 
     raise Exception("data does not match enum")
 
   def __repr__(self):
-    return "<EnumLongNames ordinal:{!r}>".format(self.ordinal)
+    return "<EnumLongNames ordinal:{!r}>".format(self._ordinal)
 
 class EnumU32:
-  def __init__(self, ordinal):
-    self.ordinal = ordinal
+  def __init__(self, _ordinal):
+    self._ordinal = _ordinal
 
-  def get_ordinal(self):
-    return self.ordinal
+  @property
+  def ordinal(self):
+    return self._ordinal
 
   def encode(self):
-    return self.ordinal
+    return self._ordinal
 
   @classmethod
   def decode(cls, data):
     for value in cls.__members__.values():
-      if value.ordinal == data:
+      if value._ordinal == data:
         return value
 
     raise Exception("data does not match enum")
 
   def __repr__(self):
-    return "<EnumU32 ordinal:{!r}>".format(self.ordinal)
+    return "<EnumU32 ordinal:{!r}>".format(self._ordinal)
 
 class EnumU64:
-  def __init__(self, ordinal):
-    self.ordinal = ordinal
+  def __init__(self, _ordinal):
+    self._ordinal = _ordinal
 
-  def get_ordinal(self):
-    return self.ordinal
+  @property
+  def ordinal(self):
+    return self._ordinal
 
   def encode(self):
-    return self.ordinal
+    return self._ordinal
 
   @classmethod
   def decode(cls, data):
     for value in cls.__members__.values():
-      if value.ordinal == data:
+      if value._ordinal == data:
         return value
 
     raise Exception("data does not match enum")
 
   def __repr__(self):
-    return "<EnumU64 ordinal:{!r}>".format(self.ordinal)
+    return "<EnumU64 ordinal:{!r}>".format(self._ordinal)
 
 class EnumI32:
-  def __init__(self, ordinal):
-    self.ordinal = ordinal
+  def __init__(self, _ordinal):
+    self._ordinal = _ordinal
 
-  def get_ordinal(self):
-    return self.ordinal
+  @property
+  def ordinal(self):
+    return self._ordinal
 
   def encode(self):
-    return self.ordinal
+    return self._ordinal
 
   @classmethod
   def decode(cls, data):
     for value in cls.__members__.values():
-      if value.ordinal == data:
+      if value._ordinal == data:
         return value
 
     raise Exception("data does not match enum")
 
   def __repr__(self):
-    return "<EnumI32 ordinal:{!r}>".format(self.ordinal)
+    return "<EnumI32 ordinal:{!r}>".format(self._ordinal)
 
 class EnumI64:
-  def __init__(self, ordinal):
-    self.ordinal = ordinal
+  def __init__(self, _ordinal):
+    self._ordinal = _ordinal
 
-  def get_ordinal(self):
-    return self.ordinal
+  @property
+  def ordinal(self):
+    return self._ordinal
 
   def encode(self):
-    return self.ordinal
+    return self._ordinal
 
   @classmethod
   def decode(cls, data):
     for value in cls.__members__.values():
-      if value.ordinal == data:
+      if value._ordinal == data:
         return value
 
     raise Exception("data does not match enum")
 
   def __repr__(self):
-    return "<EnumI64 ordinal:{!r}>".format(self.ordinal)
+    return "<EnumI64 ordinal:{!r}>".format(self._ordinal)
 
 EnumExplicit = enum.Enum("EnumExplicit", [("A", "foo"), ("B", "bar")], type=EnumExplicit)
 

--- a/it/inner/structures/default/python/test.py
+++ b/it/inner/structures/default/python/test.py
@@ -1,13 +1,15 @@
 class Entry:
-  def __init__(self, a, b):
-    self.a = a
-    self.b = b
+  def __init__(self, _a, _b):
+    self._a = _a
+    self._b = _b
 
-  def get_a(self):
-    return self.a
+  @property
+  def a(self):
+    return self._a
 
-  def get_b(self):
-    return self.b
+  @property
+  def b(self):
+    return self._b
 
   @staticmethod
   def decode(data):
@@ -32,23 +34,24 @@ class Entry:
   def encode(self):
     data = dict()
 
-    if self.a is not None:
-      data["a"] = self.a.encode()
+    if self._a is not None:
+      data["a"] = self._a.encode()
 
-    if self.b is not None:
-      data["b"] = self.b.encode()
+    if self._b is not None:
+      data["b"] = self._b.encode()
 
     return data
 
   def __repr__(self):
-    return "<Entry a:{!r}, b:{!r}>".format(self.a, self.b)
+    return "<Entry a:{!r}, b:{!r}>".format(self._a, self._b)
 
 class A:
-  def __init__(self, b):
-    self.b = b
+  def __init__(self, _b):
+    self._b = _b
 
-  def get_b(self):
-    return self.b
+  @property
+  def b(self):
+    return self._b
 
   @staticmethod
   def decode(data):
@@ -61,22 +64,23 @@ class A:
   def encode(self):
     data = dict()
 
-    if self.b is None:
+    if self._b is None:
       raise Exception("b: is a required field")
 
-    data["b"] = self.b.encode()
+    data["b"] = self._b.encode()
 
     return data
 
   def __repr__(self):
-    return "<A b:{!r}>".format(self.b)
+    return "<A b:{!r}>".format(self._b)
 
 class A_B:
-  def __init__(self, field):
-    self.field = field
+  def __init__(self, _field):
+    self._field = _field
 
-  def get_field(self):
-    return self.field
+  @property
+  def field(self):
+    return self._field
 
   @staticmethod
   def decode(data):
@@ -90,12 +94,12 @@ class A_B:
   def encode(self):
     data = dict()
 
-    if self.field is None:
+    if self._field is None:
       raise Exception("field: is a required field")
 
-    data["field"] = self.field
+    data["field"] = self._field
 
     return data
 
   def __repr__(self):
-    return "<A_B field:{!r}>".format(self.field)
+    return "<A_B field:{!r}>".format(self._field)

--- a/it/inner/structures/default/python3/test.py
+++ b/it/inner/structures/default/python3/test.py
@@ -1,13 +1,15 @@
 class Entry:
-  def __init__(self, a, b):
-    self.a = a
-    self.b = b
+  def __init__(self, _a, _b):
+    self._a = _a
+    self._b = _b
 
-  def get_a(self):
-    return self.a
+  @property
+  def a(self):
+    return self._a
 
-  def get_b(self):
-    return self.b
+  @property
+  def b(self):
+    return self._b
 
   @staticmethod
   def decode(data):
@@ -32,23 +34,24 @@ class Entry:
   def encode(self):
     data = dict()
 
-    if self.a is not None:
-      data["a"] = self.a.encode()
+    if self._a is not None:
+      data["a"] = self._a.encode()
 
-    if self.b is not None:
-      data["b"] = self.b.encode()
+    if self._b is not None:
+      data["b"] = self._b.encode()
 
     return data
 
   def __repr__(self):
-    return "<Entry a:{!r}, b:{!r}>".format(self.a, self.b)
+    return "<Entry a:{!r}, b:{!r}>".format(self._a, self._b)
 
 class A:
-  def __init__(self, b):
-    self.b = b
+  def __init__(self, _b):
+    self._b = _b
 
-  def get_b(self):
-    return self.b
+  @property
+  def b(self):
+    return self._b
 
   @staticmethod
   def decode(data):
@@ -61,22 +64,23 @@ class A:
   def encode(self):
     data = dict()
 
-    if self.b is None:
+    if self._b is None:
       raise Exception("b: is a required field")
 
-    data["b"] = self.b.encode()
+    data["b"] = self._b.encode()
 
     return data
 
   def __repr__(self):
-    return "<A b:{!r}>".format(self.b)
+    return "<A b:{!r}>".format(self._b)
 
 class A_B:
-  def __init__(self, field):
-    self.field = field
+  def __init__(self, _field):
+    self._field = _field
 
-  def get_field(self):
-    return self.field
+  @property
+  def field(self):
+    return self._field
 
   @staticmethod
   def decode(data):
@@ -90,12 +94,12 @@ class A_B:
   def encode(self):
     data = dict()
 
-    if self.field is None:
+    if self._field is None:
       raise Exception("field: is a required field")
 
-    data["field"] = self.field
+    data["field"] = self._field
 
     return data
 
   def __repr__(self):
-    return "<A_B field:{!r}>".format(self.field)
+    return "<A_B field:{!r}>".format(self._field)

--- a/it/interfaces/structures/default/python/test.py
+++ b/it/interfaces/structures/default/python/test.py
@@ -1,13 +1,15 @@
 class Entry:
-  def __init__(self, tagged, untagged):
-    self.tagged = tagged
-    self.untagged = untagged
+  def __init__(self, _tagged, _untagged):
+    self._tagged = _tagged
+    self._untagged = _untagged
 
-  def get_tagged(self):
-    return self.tagged
+  @property
+  def tagged(self):
+    return self._tagged
 
-  def get_untagged(self):
-    return self.untagged
+  @property
+  def untagged(self):
+    return self._untagged
 
   @staticmethod
   def decode(data):
@@ -32,16 +34,16 @@ class Entry:
   def encode(self):
     data = dict()
 
-    if self.tagged is not None:
-      data["tagged"] = self.tagged.encode()
+    if self._tagged is not None:
+      data["tagged"] = self._tagged.encode()
 
-    if self.untagged is not None:
-      data["untagged"] = self.untagged.encode()
+    if self._untagged is not None:
+      data["untagged"] = self._untagged.encode()
 
     return data
 
   def __repr__(self):
-    return "<Entry tagged:{!r}, untagged:{!r}>".format(self.tagged, self.untagged)
+    return "<Entry tagged:{!r}, untagged:{!r}>".format(self._tagged, self._untagged)
 
 class Tagged:
   @staticmethod
@@ -65,11 +67,12 @@ class Tagged:
 class Tagged_A:
   TYPE = "foo"
 
-  def __init__(self, shared):
-    self.shared = shared
+  def __init__(self, _shared):
+    self._shared = _shared
 
-  def get_shared(self):
-    return self.shared
+  @property
+  def shared(self):
+    return self._shared
 
   @staticmethod
   def decode(data):
@@ -85,24 +88,25 @@ class Tagged_A:
 
     data["@type"] = "foo"
 
-    if self.shared is None:
+    if self._shared is None:
       raise Exception("shared: is a required field")
 
-    data["shared"] = self.shared
+    data["shared"] = self._shared
 
     return data
 
   def __repr__(self):
-    return "<Tagged_A shared:{!r}>".format(self.shared)
+    return "<Tagged_A shared:{!r}>".format(self._shared)
 
 class Tagged_B:
   TYPE = "b"
 
-  def __init__(self, shared):
-    self.shared = shared
+  def __init__(self, _shared):
+    self._shared = _shared
 
-  def get_shared(self):
-    return self.shared
+  @property
+  def shared(self):
+    return self._shared
 
   @staticmethod
   def decode(data):
@@ -118,24 +122,25 @@ class Tagged_B:
 
     data["@type"] = "b"
 
-    if self.shared is None:
+    if self._shared is None:
       raise Exception("shared: is a required field")
 
-    data["shared"] = self.shared
+    data["shared"] = self._shared
 
     return data
 
   def __repr__(self):
-    return "<Tagged_B shared:{!r}>".format(self.shared)
+    return "<Tagged_B shared:{!r}>".format(self._shared)
 
 class Tagged_Bar:
   TYPE = "Bar"
 
-  def __init__(self, shared):
-    self.shared = shared
+  def __init__(self, _shared):
+    self._shared = _shared
 
-  def get_shared(self):
-    return self.shared
+  @property
+  def shared(self):
+    return self._shared
 
   @staticmethod
   def decode(data):
@@ -151,24 +156,25 @@ class Tagged_Bar:
 
     data["@type"] = "Bar"
 
-    if self.shared is None:
+    if self._shared is None:
       raise Exception("shared: is a required field")
 
-    data["shared"] = self.shared
+    data["shared"] = self._shared
 
     return data
 
   def __repr__(self):
-    return "<Tagged_Bar shared:{!r}>".format(self.shared)
+    return "<Tagged_Bar shared:{!r}>".format(self._shared)
 
 class Tagged_Baz:
   TYPE = "Baz"
 
-  def __init__(self, shared):
-    self.shared = shared
+  def __init__(self, _shared):
+    self._shared = _shared
 
-  def get_shared(self):
-    return self.shared
+  @property
+  def shared(self):
+    return self._shared
 
   @staticmethod
   def decode(data):
@@ -184,15 +190,15 @@ class Tagged_Baz:
 
     data["@type"] = "Baz"
 
-    if self.shared is None:
+    if self._shared is None:
       raise Exception("shared: is a required field")
 
-    data["shared"] = self.shared
+    data["shared"] = self._shared
 
     return data
 
   def __repr__(self):
-    return "<Tagged_Baz shared:{!r}>".format(self.shared)
+    return "<Tagged_Baz shared:{!r}>".format(self._shared)
 
 class Untagged:
   @staticmethod
@@ -213,27 +219,32 @@ class Untagged:
 class Untagged_A:
   TYPE = "A"
 
-  def __init__(self, shared, shared_ignore, a, b, ignore):
-    self.shared = shared
-    self.shared_ignore = shared_ignore
-    self.a = a
-    self.b = b
-    self.ignore = ignore
+  def __init__(self, _shared, _shared_ignore, _a, _b, _ignore):
+    self._shared = _shared
+    self._shared_ignore = _shared_ignore
+    self._a = _a
+    self._b = _b
+    self._ignore = _ignore
 
-  def get_shared(self):
-    return self.shared
+  @property
+  def shared(self):
+    return self._shared
 
-  def get_shared_ignore(self):
-    return self.shared_ignore
+  @property
+  def shared_ignore(self):
+    return self._shared_ignore
 
-  def get_a(self):
-    return self.a
+  @property
+  def a(self):
+    return self._a
 
-  def get_b(self):
-    return self.b
+  @property
+  def b(self):
+    return self._b
 
-  def get_ignore(self):
-    return self.ignore
+  @property
+  def ignore(self):
+    return self._ignore
 
   @staticmethod
   def decode(data):
@@ -275,52 +286,56 @@ class Untagged_A:
   def encode(self):
     data = dict()
 
-    if self.shared is None:
+    if self._shared is None:
       raise Exception("shared: is a required field")
 
-    data["shared"] = self.shared
+    data["shared"] = self._shared
 
-    if self.shared_ignore is not None:
-      data["shared_ignore"] = self.shared_ignore
+    if self._shared_ignore is not None:
+      data["shared_ignore"] = self._shared_ignore
 
-    if self.a is None:
+    if self._a is None:
       raise Exception("a: is a required field")
 
-    data["a"] = self.a
+    data["a"] = self._a
 
-    if self.b is None:
+    if self._b is None:
       raise Exception("b: is a required field")
 
-    data["b"] = self.b
+    data["b"] = self._b
 
-    if self.ignore is not None:
-      data["ignore"] = self.ignore
+    if self._ignore is not None:
+      data["ignore"] = self._ignore
 
     return data
 
   def __repr__(self):
-    return "<Untagged_A shared:{!r}, shared_ignore:{!r}, a:{!r}, b:{!r}, ignore:{!r}>".format(self.shared, self.shared_ignore, self.a, self.b, self.ignore)
+    return "<Untagged_A shared:{!r}, shared_ignore:{!r}, a:{!r}, b:{!r}, ignore:{!r}>".format(self._shared, self._shared_ignore, self._a, self._b, self._ignore)
 
 class Untagged_B:
   TYPE = "B"
 
-  def __init__(self, shared, shared_ignore, a, ignore):
-    self.shared = shared
-    self.shared_ignore = shared_ignore
-    self.a = a
-    self.ignore = ignore
+  def __init__(self, _shared, _shared_ignore, _a, _ignore):
+    self._shared = _shared
+    self._shared_ignore = _shared_ignore
+    self._a = _a
+    self._ignore = _ignore
 
-  def get_shared(self):
-    return self.shared
+  @property
+  def shared(self):
+    return self._shared
 
-  def get_shared_ignore(self):
-    return self.shared_ignore
+  @property
+  def shared_ignore(self):
+    return self._shared_ignore
 
-  def get_a(self):
-    return self.a
+  @property
+  def a(self):
+    return self._a
 
-  def get_ignore(self):
-    return self.ignore
+  @property
+  def ignore(self):
+    return self._ignore
 
   @staticmethod
   def decode(data):
@@ -357,47 +372,51 @@ class Untagged_B:
   def encode(self):
     data = dict()
 
-    if self.shared is None:
+    if self._shared is None:
       raise Exception("shared: is a required field")
 
-    data["shared"] = self.shared
+    data["shared"] = self._shared
 
-    if self.shared_ignore is not None:
-      data["shared_ignore"] = self.shared_ignore
+    if self._shared_ignore is not None:
+      data["shared_ignore"] = self._shared_ignore
 
-    if self.a is None:
+    if self._a is None:
       raise Exception("a: is a required field")
 
-    data["a"] = self.a
+    data["a"] = self._a
 
-    if self.ignore is not None:
-      data["ignore"] = self.ignore
+    if self._ignore is not None:
+      data["ignore"] = self._ignore
 
     return data
 
   def __repr__(self):
-    return "<Untagged_B shared:{!r}, shared_ignore:{!r}, a:{!r}, ignore:{!r}>".format(self.shared, self.shared_ignore, self.a, self.ignore)
+    return "<Untagged_B shared:{!r}, shared_ignore:{!r}, a:{!r}, ignore:{!r}>".format(self._shared, self._shared_ignore, self._a, self._ignore)
 
 class Untagged_C:
   TYPE = "C"
 
-  def __init__(self, shared, shared_ignore, b, ignore):
-    self.shared = shared
-    self.shared_ignore = shared_ignore
-    self.b = b
-    self.ignore = ignore
+  def __init__(self, _shared, _shared_ignore, _b, _ignore):
+    self._shared = _shared
+    self._shared_ignore = _shared_ignore
+    self._b = _b
+    self._ignore = _ignore
 
-  def get_shared(self):
-    return self.shared
+  @property
+  def shared(self):
+    return self._shared
 
-  def get_shared_ignore(self):
-    return self.shared_ignore
+  @property
+  def shared_ignore(self):
+    return self._shared_ignore
 
-  def get_b(self):
-    return self.b
+  @property
+  def b(self):
+    return self._b
 
-  def get_ignore(self):
-    return self.ignore
+  @property
+  def ignore(self):
+    return self._ignore
 
   @staticmethod
   def decode(data):
@@ -434,23 +453,23 @@ class Untagged_C:
   def encode(self):
     data = dict()
 
-    if self.shared is None:
+    if self._shared is None:
       raise Exception("shared: is a required field")
 
-    data["shared"] = self.shared
+    data["shared"] = self._shared
 
-    if self.shared_ignore is not None:
-      data["shared_ignore"] = self.shared_ignore
+    if self._shared_ignore is not None:
+      data["shared_ignore"] = self._shared_ignore
 
-    if self.b is None:
+    if self._b is None:
       raise Exception("b: is a required field")
 
-    data["b"] = self.b
+    data["b"] = self._b
 
-    if self.ignore is not None:
-      data["ignore"] = self.ignore
+    if self._ignore is not None:
+      data["ignore"] = self._ignore
 
     return data
 
   def __repr__(self):
-    return "<Untagged_C shared:{!r}, shared_ignore:{!r}, b:{!r}, ignore:{!r}>".format(self.shared, self.shared_ignore, self.b, self.ignore)
+    return "<Untagged_C shared:{!r}, shared_ignore:{!r}, b:{!r}, ignore:{!r}>".format(self._shared, self._shared_ignore, self._b, self._ignore)

--- a/it/interfaces/structures/default/python3/test.py
+++ b/it/interfaces/structures/default/python3/test.py
@@ -1,13 +1,15 @@
 class Entry:
-  def __init__(self, tagged, untagged):
-    self.tagged = tagged
-    self.untagged = untagged
+  def __init__(self, _tagged, _untagged):
+    self._tagged = _tagged
+    self._untagged = _untagged
 
-  def get_tagged(self):
-    return self.tagged
+  @property
+  def tagged(self):
+    return self._tagged
 
-  def get_untagged(self):
-    return self.untagged
+  @property
+  def untagged(self):
+    return self._untagged
 
   @staticmethod
   def decode(data):
@@ -32,16 +34,16 @@ class Entry:
   def encode(self):
     data = dict()
 
-    if self.tagged is not None:
-      data["tagged"] = self.tagged.encode()
+    if self._tagged is not None:
+      data["tagged"] = self._tagged.encode()
 
-    if self.untagged is not None:
-      data["untagged"] = self.untagged.encode()
+    if self._untagged is not None:
+      data["untagged"] = self._untagged.encode()
 
     return data
 
   def __repr__(self):
-    return "<Entry tagged:{!r}, untagged:{!r}>".format(self.tagged, self.untagged)
+    return "<Entry tagged:{!r}, untagged:{!r}>".format(self._tagged, self._untagged)
 
 class Tagged:
   @staticmethod
@@ -65,11 +67,12 @@ class Tagged:
 class Tagged_A:
   TYPE = "foo"
 
-  def __init__(self, shared):
-    self.shared = shared
+  def __init__(self, _shared):
+    self._shared = _shared
 
-  def get_shared(self):
-    return self.shared
+  @property
+  def shared(self):
+    return self._shared
 
   @staticmethod
   def decode(data):
@@ -85,24 +88,25 @@ class Tagged_A:
 
     data["@type"] = "foo"
 
-    if self.shared is None:
+    if self._shared is None:
       raise Exception("shared: is a required field")
 
-    data["shared"] = self.shared
+    data["shared"] = self._shared
 
     return data
 
   def __repr__(self):
-    return "<Tagged_A shared:{!r}>".format(self.shared)
+    return "<Tagged_A shared:{!r}>".format(self._shared)
 
 class Tagged_B:
   TYPE = "b"
 
-  def __init__(self, shared):
-    self.shared = shared
+  def __init__(self, _shared):
+    self._shared = _shared
 
-  def get_shared(self):
-    return self.shared
+  @property
+  def shared(self):
+    return self._shared
 
   @staticmethod
   def decode(data):
@@ -118,24 +122,25 @@ class Tagged_B:
 
     data["@type"] = "b"
 
-    if self.shared is None:
+    if self._shared is None:
       raise Exception("shared: is a required field")
 
-    data["shared"] = self.shared
+    data["shared"] = self._shared
 
     return data
 
   def __repr__(self):
-    return "<Tagged_B shared:{!r}>".format(self.shared)
+    return "<Tagged_B shared:{!r}>".format(self._shared)
 
 class Tagged_Bar:
   TYPE = "Bar"
 
-  def __init__(self, shared):
-    self.shared = shared
+  def __init__(self, _shared):
+    self._shared = _shared
 
-  def get_shared(self):
-    return self.shared
+  @property
+  def shared(self):
+    return self._shared
 
   @staticmethod
   def decode(data):
@@ -151,24 +156,25 @@ class Tagged_Bar:
 
     data["@type"] = "Bar"
 
-    if self.shared is None:
+    if self._shared is None:
       raise Exception("shared: is a required field")
 
-    data["shared"] = self.shared
+    data["shared"] = self._shared
 
     return data
 
   def __repr__(self):
-    return "<Tagged_Bar shared:{!r}>".format(self.shared)
+    return "<Tagged_Bar shared:{!r}>".format(self._shared)
 
 class Tagged_Baz:
   TYPE = "Baz"
 
-  def __init__(self, shared):
-    self.shared = shared
+  def __init__(self, _shared):
+    self._shared = _shared
 
-  def get_shared(self):
-    return self.shared
+  @property
+  def shared(self):
+    return self._shared
 
   @staticmethod
   def decode(data):
@@ -184,15 +190,15 @@ class Tagged_Baz:
 
     data["@type"] = "Baz"
 
-    if self.shared is None:
+    if self._shared is None:
       raise Exception("shared: is a required field")
 
-    data["shared"] = self.shared
+    data["shared"] = self._shared
 
     return data
 
   def __repr__(self):
-    return "<Tagged_Baz shared:{!r}>".format(self.shared)
+    return "<Tagged_Baz shared:{!r}>".format(self._shared)
 
 class Untagged:
   @staticmethod
@@ -213,27 +219,32 @@ class Untagged:
 class Untagged_A:
   TYPE = "A"
 
-  def __init__(self, shared, shared_ignore, a, b, ignore):
-    self.shared = shared
-    self.shared_ignore = shared_ignore
-    self.a = a
-    self.b = b
-    self.ignore = ignore
+  def __init__(self, _shared, _shared_ignore, _a, _b, _ignore):
+    self._shared = _shared
+    self._shared_ignore = _shared_ignore
+    self._a = _a
+    self._b = _b
+    self._ignore = _ignore
 
-  def get_shared(self):
-    return self.shared
+  @property
+  def shared(self):
+    return self._shared
 
-  def get_shared_ignore(self):
-    return self.shared_ignore
+  @property
+  def shared_ignore(self):
+    return self._shared_ignore
 
-  def get_a(self):
-    return self.a
+  @property
+  def a(self):
+    return self._a
 
-  def get_b(self):
-    return self.b
+  @property
+  def b(self):
+    return self._b
 
-  def get_ignore(self):
-    return self.ignore
+  @property
+  def ignore(self):
+    return self._ignore
 
   @staticmethod
   def decode(data):
@@ -275,52 +286,56 @@ class Untagged_A:
   def encode(self):
     data = dict()
 
-    if self.shared is None:
+    if self._shared is None:
       raise Exception("shared: is a required field")
 
-    data["shared"] = self.shared
+    data["shared"] = self._shared
 
-    if self.shared_ignore is not None:
-      data["shared_ignore"] = self.shared_ignore
+    if self._shared_ignore is not None:
+      data["shared_ignore"] = self._shared_ignore
 
-    if self.a is None:
+    if self._a is None:
       raise Exception("a: is a required field")
 
-    data["a"] = self.a
+    data["a"] = self._a
 
-    if self.b is None:
+    if self._b is None:
       raise Exception("b: is a required field")
 
-    data["b"] = self.b
+    data["b"] = self._b
 
-    if self.ignore is not None:
-      data["ignore"] = self.ignore
+    if self._ignore is not None:
+      data["ignore"] = self._ignore
 
     return data
 
   def __repr__(self):
-    return "<Untagged_A shared:{!r}, shared_ignore:{!r}, a:{!r}, b:{!r}, ignore:{!r}>".format(self.shared, self.shared_ignore, self.a, self.b, self.ignore)
+    return "<Untagged_A shared:{!r}, shared_ignore:{!r}, a:{!r}, b:{!r}, ignore:{!r}>".format(self._shared, self._shared_ignore, self._a, self._b, self._ignore)
 
 class Untagged_B:
   TYPE = "B"
 
-  def __init__(self, shared, shared_ignore, a, ignore):
-    self.shared = shared
-    self.shared_ignore = shared_ignore
-    self.a = a
-    self.ignore = ignore
+  def __init__(self, _shared, _shared_ignore, _a, _ignore):
+    self._shared = _shared
+    self._shared_ignore = _shared_ignore
+    self._a = _a
+    self._ignore = _ignore
 
-  def get_shared(self):
-    return self.shared
+  @property
+  def shared(self):
+    return self._shared
 
-  def get_shared_ignore(self):
-    return self.shared_ignore
+  @property
+  def shared_ignore(self):
+    return self._shared_ignore
 
-  def get_a(self):
-    return self.a
+  @property
+  def a(self):
+    return self._a
 
-  def get_ignore(self):
-    return self.ignore
+  @property
+  def ignore(self):
+    return self._ignore
 
   @staticmethod
   def decode(data):
@@ -357,47 +372,51 @@ class Untagged_B:
   def encode(self):
     data = dict()
 
-    if self.shared is None:
+    if self._shared is None:
       raise Exception("shared: is a required field")
 
-    data["shared"] = self.shared
+    data["shared"] = self._shared
 
-    if self.shared_ignore is not None:
-      data["shared_ignore"] = self.shared_ignore
+    if self._shared_ignore is not None:
+      data["shared_ignore"] = self._shared_ignore
 
-    if self.a is None:
+    if self._a is None:
       raise Exception("a: is a required field")
 
-    data["a"] = self.a
+    data["a"] = self._a
 
-    if self.ignore is not None:
-      data["ignore"] = self.ignore
+    if self._ignore is not None:
+      data["ignore"] = self._ignore
 
     return data
 
   def __repr__(self):
-    return "<Untagged_B shared:{!r}, shared_ignore:{!r}, a:{!r}, ignore:{!r}>".format(self.shared, self.shared_ignore, self.a, self.ignore)
+    return "<Untagged_B shared:{!r}, shared_ignore:{!r}, a:{!r}, ignore:{!r}>".format(self._shared, self._shared_ignore, self._a, self._ignore)
 
 class Untagged_C:
   TYPE = "C"
 
-  def __init__(self, shared, shared_ignore, b, ignore):
-    self.shared = shared
-    self.shared_ignore = shared_ignore
-    self.b = b
-    self.ignore = ignore
+  def __init__(self, _shared, _shared_ignore, _b, _ignore):
+    self._shared = _shared
+    self._shared_ignore = _shared_ignore
+    self._b = _b
+    self._ignore = _ignore
 
-  def get_shared(self):
-    return self.shared
+  @property
+  def shared(self):
+    return self._shared
 
-  def get_shared_ignore(self):
-    return self.shared_ignore
+  @property
+  def shared_ignore(self):
+    return self._shared_ignore
 
-  def get_b(self):
-    return self.b
+  @property
+  def b(self):
+    return self._b
 
-  def get_ignore(self):
-    return self.ignore
+  @property
+  def ignore(self):
+    return self._ignore
 
   @staticmethod
   def decode(data):
@@ -434,23 +453,23 @@ class Untagged_C:
   def encode(self):
     data = dict()
 
-    if self.shared is None:
+    if self._shared is None:
       raise Exception("shared: is a required field")
 
-    data["shared"] = self.shared
+    data["shared"] = self._shared
 
-    if self.shared_ignore is not None:
-      data["shared_ignore"] = self.shared_ignore
+    if self._shared_ignore is not None:
+      data["shared_ignore"] = self._shared_ignore
 
-    if self.b is None:
+    if self._b is None:
       raise Exception("b: is a required field")
 
-    data["b"] = self.b
+    data["b"] = self._b
 
-    if self.ignore is not None:
-      data["ignore"] = self.ignore
+    if self._ignore is not None:
+      data["ignore"] = self._ignore
 
     return data
 
   def __repr__(self):
-    return "<Untagged_C shared:{!r}, shared_ignore:{!r}, b:{!r}, ignore:{!r}>".format(self.shared, self.shared_ignore, self.b, self.ignore)
+    return "<Untagged_C shared:{!r}, shared_ignore:{!r}, b:{!r}, ignore:{!r}>".format(self._shared, self._shared_ignore, self._b, self._ignore)

--- a/it/python_keywords/structures/default/python/test.py
+++ b/it/python_keywords/structures/default/python/test.py
@@ -1,7 +1,7 @@
 import _yield as t
 
 class Entry:
-  def __init__(self, _and, _as, _assert, _break, _class, _continue, _def, _del, _elif, _else, _except, _exec, _finally, _for, _from, _global, _if, _import, imported, _in, _is, _lambda, _nonlocal, _not, _or, _pass, _print, _raise, _return, _try, _while, _with, _yield):
+  def __init__(self, _and, _as, _assert, _break, _class, _continue, _def, _del, _elif, _else, _except, _exec, _finally, _for, _from, _global, _if, _import, _imported, _in, _is, _lambda, _nonlocal, _not, _or, _pass, _print, _raise, _return, _try, _while, _with, _yield):
     self._and = _and
     self._as = _as
     self._assert = _assert
@@ -20,7 +20,7 @@ class Entry:
     self._global = _global
     self._if = _if
     self._import = _import
-    self.imported = imported
+    self._imported = _imported
     self._in = _in
     self._is = _is
     self._lambda = _lambda
@@ -36,267 +36,300 @@ class Entry:
     self._with = _with
     self._yield = _yield
 
-  def get_and(self):
+  @property
+  def and(self):
     return self._and
 
-  def get_as(self):
+  @property
+  def as(self):
     return self._as
 
-  def get_assert(self):
+  @property
+  def assert(self):
     return self._assert
 
-  def get_break(self):
+  @property
+  def break(self):
     return self._break
 
-  def get_class(self):
+  @property
+  def class(self):
     return self._class
 
-  def get_continue(self):
+  @property
+  def continue(self):
     return self._continue
 
-  def get_def(self):
+  @property
+  def def(self):
     return self._def
 
-  def get_del(self):
+  @property
+  def del(self):
     return self._del
 
-  def get_elif(self):
+  @property
+  def elif(self):
     return self._elif
 
-  def get_else(self):
+  @property
+  def else(self):
     return self._else
 
-  def get_except(self):
+  @property
+  def except(self):
     return self._except
 
-  def get_exec(self):
+  @property
+  def exec(self):
     return self._exec
 
-  def get_finally(self):
+  @property
+  def finally(self):
     return self._finally
 
-  def get_for(self):
+  @property
+  def for(self):
     return self._for
 
-  def get_from(self):
+  @property
+  def from(self):
     return self._from
 
-  def get_global(self):
+  @property
+  def global(self):
     return self._global
 
-  def get_if(self):
+  @property
+  def if(self):
     return self._if
 
-  def get_import(self):
+  @property
+  def import(self):
     return self._import
 
-  def get_imported(self):
-    return self.imported
+  @property
+  def imported(self):
+    return self._imported
 
-  def get_in(self):
+  @property
+  def in(self):
     return self._in
 
-  def get_is(self):
+  @property
+  def is(self):
     return self._is
 
-  def get_lambda(self):
+  @property
+  def lambda(self):
     return self._lambda
 
-  def get_nonlocal(self):
+  @property
+  def nonlocal(self):
     return self._nonlocal
 
-  def get_not(self):
+  @property
+  def not(self):
     return self._not
 
-  def get_or(self):
+  @property
+  def or(self):
     return self._or
 
-  def get_pass(self):
+  @property
+  def pass(self):
     return self._pass
 
-  def get_print(self):
+  @property
+  def print(self):
     return self._print
 
-  def get_raise(self):
+  @property
+  def raise(self):
     return self._raise
 
-  def get_return(self):
+  @property
+  def return(self):
     return self._return
 
-  def get_try(self):
+  @property
+  def try(self):
     return self._try
 
-  def get_while(self):
+  @property
+  def while(self):
     return self._while
 
-  def get_with(self):
+  @property
+  def with(self):
     return self._with
 
-  def get_yield(self):
+  @property
+  def yield(self):
     return self._yield
 
   @staticmethod
   def decode(data):
-    f__and = None
+    f_and = None
 
     if "and" in data:
-      f__and = data["and"]
+      f_and = data["and"]
 
-      if f__and is not None:
-        if not isinstance(f__and, unicode):
+      if f_and is not None:
+        if not isinstance(f_and, unicode):
           raise Exception("not a string")
 
-    f__as = None
+    f_as = None
 
     if "as" in data:
-      f__as = data["as"]
+      f_as = data["as"]
 
-      if f__as is not None:
-        if not isinstance(f__as, unicode):
+      if f_as is not None:
+        if not isinstance(f_as, unicode):
           raise Exception("not a string")
 
-    f__assert = None
+    f_assert = None
 
     if "assert" in data:
-      f__assert = data["assert"]
+      f_assert = data["assert"]
 
-      if f__assert is not None:
-        if not isinstance(f__assert, unicode):
+      if f_assert is not None:
+        if not isinstance(f_assert, unicode):
           raise Exception("not a string")
 
-    f__break = None
+    f_break = None
 
     if "break" in data:
-      f__break = data["break"]
+      f_break = data["break"]
 
-      if f__break is not None:
-        if not isinstance(f__break, unicode):
+      if f_break is not None:
+        if not isinstance(f_break, unicode):
           raise Exception("not a string")
 
-    f__class = None
+    f_class = None
 
     if "class" in data:
-      f__class = data["class"]
+      f_class = data["class"]
 
-      if f__class is not None:
-        if not isinstance(f__class, unicode):
+      if f_class is not None:
+        if not isinstance(f_class, unicode):
           raise Exception("not a string")
 
-    f__continue = None
+    f_continue = None
 
     if "continue" in data:
-      f__continue = data["continue"]
+      f_continue = data["continue"]
 
-      if f__continue is not None:
-        if not isinstance(f__continue, unicode):
+      if f_continue is not None:
+        if not isinstance(f_continue, unicode):
           raise Exception("not a string")
 
-    f__def = None
+    f_def = None
 
     if "def" in data:
-      f__def = data["def"]
+      f_def = data["def"]
 
-      if f__def is not None:
-        if not isinstance(f__def, unicode):
+      if f_def is not None:
+        if not isinstance(f_def, unicode):
           raise Exception("not a string")
 
-    f__del = None
+    f_del = None
 
     if "del" in data:
-      f__del = data["del"]
+      f_del = data["del"]
 
-      if f__del is not None:
-        if not isinstance(f__del, unicode):
+      if f_del is not None:
+        if not isinstance(f_del, unicode):
           raise Exception("not a string")
 
-    f__elif = None
+    f_elif = None
 
     if "elif" in data:
-      f__elif = data["elif"]
+      f_elif = data["elif"]
 
-      if f__elif is not None:
-        if not isinstance(f__elif, unicode):
+      if f_elif is not None:
+        if not isinstance(f_elif, unicode):
           raise Exception("not a string")
 
-    f__else = None
+    f_else = None
 
     if "else" in data:
-      f__else = data["else"]
+      f_else = data["else"]
 
-      if f__else is not None:
-        if not isinstance(f__else, unicode):
+      if f_else is not None:
+        if not isinstance(f_else, unicode):
           raise Exception("not a string")
 
-    f__except = None
+    f_except = None
 
     if "except" in data:
-      f__except = data["except"]
+      f_except = data["except"]
 
-      if f__except is not None:
-        if not isinstance(f__except, unicode):
+      if f_except is not None:
+        if not isinstance(f_except, unicode):
           raise Exception("not a string")
 
-    f__exec = None
+    f_exec = None
 
     if "exec" in data:
-      f__exec = data["exec"]
+      f_exec = data["exec"]
 
-      if f__exec is not None:
-        if not isinstance(f__exec, unicode):
+      if f_exec is not None:
+        if not isinstance(f_exec, unicode):
           raise Exception("not a string")
 
-    f__finally = None
+    f_finally = None
 
     if "finally" in data:
-      f__finally = data["finally"]
+      f_finally = data["finally"]
 
-      if f__finally is not None:
-        if not isinstance(f__finally, unicode):
+      if f_finally is not None:
+        if not isinstance(f_finally, unicode):
           raise Exception("not a string")
 
-    f__for = None
+    f_for = None
 
     if "for" in data:
-      f__for = data["for"]
+      f_for = data["for"]
 
-      if f__for is not None:
-        if not isinstance(f__for, unicode):
+      if f_for is not None:
+        if not isinstance(f_for, unicode):
           raise Exception("not a string")
 
-    f__from = None
+    f_from = None
 
     if "from" in data:
-      f__from = data["from"]
+      f_from = data["from"]
 
-      if f__from is not None:
-        if not isinstance(f__from, unicode):
+      if f_from is not None:
+        if not isinstance(f_from, unicode):
           raise Exception("not a string")
 
-    f__global = None
+    f_global = None
 
     if "global" in data:
-      f__global = data["global"]
+      f_global = data["global"]
 
-      if f__global is not None:
-        if not isinstance(f__global, unicode):
+      if f_global is not None:
+        if not isinstance(f_global, unicode):
           raise Exception("not a string")
 
-    f__if = None
+    f_if = None
 
     if "if" in data:
-      f__if = data["if"]
+      f_if = data["if"]
 
-      if f__if is not None:
-        if not isinstance(f__if, unicode):
+      if f_if is not None:
+        if not isinstance(f_if, unicode):
           raise Exception("not a string")
 
-    f__import = None
+    f_import = None
 
     if "import" in data:
-      f__import = data["import"]
+      f_import = data["import"]
 
-      if f__import is not None:
-        if not isinstance(f__import, unicode):
+      if f_import is not None:
+        if not isinstance(f_import, unicode):
           raise Exception("not a string")
 
     f_imported = None
@@ -307,133 +340,133 @@ class Entry:
       if f_imported is not None:
         f_imported = t.Empty.decode(f_imported)
 
-    f__in = None
+    f_in = None
 
     if "in" in data:
-      f__in = data["in"]
+      f_in = data["in"]
 
-      if f__in is not None:
-        if not isinstance(f__in, unicode):
+      if f_in is not None:
+        if not isinstance(f_in, unicode):
           raise Exception("not a string")
 
-    f__is = None
+    f_is = None
 
     if "is" in data:
-      f__is = data["is"]
+      f_is = data["is"]
 
-      if f__is is not None:
-        if not isinstance(f__is, unicode):
+      if f_is is not None:
+        if not isinstance(f_is, unicode):
           raise Exception("not a string")
 
-    f__lambda = None
+    f_lambda = None
 
     if "lambda" in data:
-      f__lambda = data["lambda"]
+      f_lambda = data["lambda"]
 
-      if f__lambda is not None:
-        if not isinstance(f__lambda, unicode):
+      if f_lambda is not None:
+        if not isinstance(f_lambda, unicode):
           raise Exception("not a string")
 
-    f__nonlocal = None
+    f_nonlocal = None
 
     if "nonlocal" in data:
-      f__nonlocal = data["nonlocal"]
+      f_nonlocal = data["nonlocal"]
 
-      if f__nonlocal is not None:
-        if not isinstance(f__nonlocal, unicode):
+      if f_nonlocal is not None:
+        if not isinstance(f_nonlocal, unicode):
           raise Exception("not a string")
 
-    f__not = None
+    f_not = None
 
     if "not" in data:
-      f__not = data["not"]
+      f_not = data["not"]
 
-      if f__not is not None:
-        if not isinstance(f__not, unicode):
+      if f_not is not None:
+        if not isinstance(f_not, unicode):
           raise Exception("not a string")
 
-    f__or = None
+    f_or = None
 
     if "or" in data:
-      f__or = data["or"]
+      f_or = data["or"]
 
-      if f__or is not None:
-        if not isinstance(f__or, unicode):
+      if f_or is not None:
+        if not isinstance(f_or, unicode):
           raise Exception("not a string")
 
-    f__pass = None
+    f_pass = None
 
     if "pass" in data:
-      f__pass = data["pass"]
+      f_pass = data["pass"]
 
-      if f__pass is not None:
-        if not isinstance(f__pass, unicode):
+      if f_pass is not None:
+        if not isinstance(f_pass, unicode):
           raise Exception("not a string")
 
-    f__print = None
+    f_print = None
 
     if "print" in data:
-      f__print = data["print"]
+      f_print = data["print"]
 
-      if f__print is not None:
-        if not isinstance(f__print, unicode):
+      if f_print is not None:
+        if not isinstance(f_print, unicode):
           raise Exception("not a string")
 
-    f__raise = None
+    f_raise = None
 
     if "raise" in data:
-      f__raise = data["raise"]
+      f_raise = data["raise"]
 
-      if f__raise is not None:
-        if not isinstance(f__raise, unicode):
+      if f_raise is not None:
+        if not isinstance(f_raise, unicode):
           raise Exception("not a string")
 
-    f__return = None
+    f_return = None
 
     if "return" in data:
-      f__return = data["return"]
+      f_return = data["return"]
 
-      if f__return is not None:
-        if not isinstance(f__return, unicode):
+      if f_return is not None:
+        if not isinstance(f_return, unicode):
           raise Exception("not a string")
 
-    f__try = None
+    f_try = None
 
     if "try" in data:
-      f__try = data["try"]
+      f_try = data["try"]
 
-      if f__try is not None:
-        if not isinstance(f__try, unicode):
+      if f_try is not None:
+        if not isinstance(f_try, unicode):
           raise Exception("not a string")
 
-    f__while = None
+    f_while = None
 
     if "while" in data:
-      f__while = data["while"]
+      f_while = data["while"]
 
-      if f__while is not None:
-        if not isinstance(f__while, unicode):
+      if f_while is not None:
+        if not isinstance(f_while, unicode):
           raise Exception("not a string")
 
-    f__with = None
+    f_with = None
 
     if "with" in data:
-      f__with = data["with"]
+      f_with = data["with"]
 
-      if f__with is not None:
-        if not isinstance(f__with, unicode):
+      if f_with is not None:
+        if not isinstance(f_with, unicode):
           raise Exception("not a string")
 
-    f__yield = None
+    f_yield = None
 
     if "yield" in data:
-      f__yield = data["yield"]
+      f_yield = data["yield"]
 
-      if f__yield is not None:
-        if not isinstance(f__yield, unicode):
+      if f_yield is not None:
+        if not isinstance(f_yield, unicode):
           raise Exception("not a string")
 
-    return Entry(f__and, f__as, f__assert, f__break, f__class, f__continue, f__def, f__del, f__elif, f__else, f__except, f__exec, f__finally, f__for, f__from, f__global, f__if, f__import, f_imported, f__in, f__is, f__lambda, f__nonlocal, f__not, f__or, f__pass, f__print, f__raise, f__return, f__try, f__while, f__with, f__yield)
+    return Entry(f_and, f_as, f_assert, f_break, f_class, f_continue, f_def, f_del, f_elif, f_else, f_except, f_exec, f_finally, f_for, f_from, f_global, f_if, f_import, f_imported, f_in, f_is, f_lambda, f_nonlocal, f_not, f_or, f_pass, f_print, f_raise, f_return, f_try, f_while, f_with, f_yield)
 
   def encode(self):
     data = dict()
@@ -492,8 +525,8 @@ class Entry:
     if self._import is not None:
       data["import"] = self._import
 
-    if self.imported is not None:
-      data["imported"] = self.imported.encode()
+    if self._imported is not None:
+      data["imported"] = self._imported.encode()
 
     if self._in is not None:
       data["in"] = self._in
@@ -540,4 +573,4 @@ class Entry:
     return data
 
   def __repr__(self):
-    return "<Entry and:{!r}, as:{!r}, assert:{!r}, break:{!r}, class:{!r}, continue:{!r}, def:{!r}, del:{!r}, elif:{!r}, else:{!r}, except:{!r}, exec:{!r}, finally:{!r}, for:{!r}, from:{!r}, global:{!r}, if:{!r}, import:{!r}, imported:{!r}, in:{!r}, is:{!r}, lambda:{!r}, nonlocal:{!r}, not:{!r}, or:{!r}, pass:{!r}, print:{!r}, raise:{!r}, return:{!r}, try:{!r}, while:{!r}, with:{!r}, yield:{!r}>".format(self._and, self._as, self._assert, self._break, self._class, self._continue, self._def, self._del, self._elif, self._else, self._except, self._exec, self._finally, self._for, self._from, self._global, self._if, self._import, self.imported, self._in, self._is, self._lambda, self._nonlocal, self._not, self._or, self._pass, self._print, self._raise, self._return, self._try, self._while, self._with, self._yield)
+    return "<Entry and:{!r}, as:{!r}, assert:{!r}, break:{!r}, class:{!r}, continue:{!r}, def:{!r}, del:{!r}, elif:{!r}, else:{!r}, except:{!r}, exec:{!r}, finally:{!r}, for:{!r}, from:{!r}, global:{!r}, if:{!r}, import:{!r}, imported:{!r}, in:{!r}, is:{!r}, lambda:{!r}, nonlocal:{!r}, not:{!r}, or:{!r}, pass:{!r}, print:{!r}, raise:{!r}, return:{!r}, try:{!r}, while:{!r}, with:{!r}, yield:{!r}>".format(self._and, self._as, self._assert, self._break, self._class, self._continue, self._def, self._del, self._elif, self._else, self._except, self._exec, self._finally, self._for, self._from, self._global, self._if, self._import, self._imported, self._in, self._is, self._lambda, self._nonlocal, self._not, self._or, self._pass, self._print, self._raise, self._return, self._try, self._while, self._with, self._yield)

--- a/it/tuple/structures/default/python/test.py
+++ b/it/tuple/structures/default/python/test.py
@@ -1,13 +1,15 @@
 class Entry:
-  def __init__(self, tuple1, tuple2):
-    self.tuple1 = tuple1
-    self.tuple2 = tuple2
+  def __init__(self, _tuple1, _tuple2):
+    self._tuple1 = _tuple1
+    self._tuple2 = _tuple2
 
-  def get_tuple1(self):
-    return self.tuple1
+  @property
+  def tuple1(self):
+    return self._tuple1
 
-  def get_tuple2(self):
-    return self.tuple2
+  @property
+  def tuple2(self):
+    return self._tuple2
 
   @staticmethod
   def decode(data):
@@ -32,27 +34,29 @@ class Entry:
   def encode(self):
     data = dict()
 
-    if self.tuple1 is not None:
-      data["tuple1"] = self.tuple1.encode()
+    if self._tuple1 is not None:
+      data["tuple1"] = self._tuple1.encode()
 
-    if self.tuple2 is not None:
-      data["tuple2"] = self.tuple2.encode()
+    if self._tuple2 is not None:
+      data["tuple2"] = self._tuple2.encode()
 
     return data
 
   def __repr__(self):
-    return "<Entry tuple1:{!r}, tuple2:{!r}>".format(self.tuple1, self.tuple2)
+    return "<Entry tuple1:{!r}, tuple2:{!r}>".format(self._tuple1, self._tuple2)
 
 class Tuple1:
-  def __init__(self, a, b):
-    self.a = a
-    self.b = b
+  def __init__(self, _a, _b):
+    self._a = _a
+    self._b = _b
 
-  def get_a(self):
-    return self.a
+  @property
+  def a(self):
+    return self._a
 
-  def get_b(self):
-    return self.b
+  @property
+  def b(self):
+    return self._b
 
   @staticmethod
   def decode(data):
@@ -69,27 +73,29 @@ class Tuple1:
     return Tuple1(f_a, f_b)
 
   def encode(self):
-    if self.a is None:
+    if self._a is None:
       raise Exception("a: is a required field")
 
-    if self.b is None:
+    if self._b is None:
       raise Exception("b: is a required field")
 
-    return (self.a, self.b)
+    return (self._a, self._b)
 
   def __repr__(self):
-    return "<Tuple1 a:{!r}, b:{!r}>".format(self.a, self.b)
+    return "<Tuple1 a:{!r}, b:{!r}>".format(self._a, self._b)
 
 class Tuple2:
-  def __init__(self, a, b):
-    self.a = a
-    self.b = b
+  def __init__(self, _a, _b):
+    self._a = _a
+    self._b = _b
 
-  def get_a(self):
-    return self.a
+  @property
+  def a(self):
+    return self._a
 
-  def get_b(self):
-    return self.b
+  @property
+  def b(self):
+    return self._b
 
   @staticmethod
   def decode(data):
@@ -105,23 +111,24 @@ class Tuple2:
     return Tuple2(f_a, f_b)
 
   def encode(self):
-    if self.a is None:
+    if self._a is None:
       raise Exception("a: is a required field")
 
-    if self.b is None:
+    if self._b is None:
       raise Exception("b: is a required field")
 
-    return (self.a, self.b.encode())
+    return (self._a, self._b.encode())
 
   def __repr__(self):
-    return "<Tuple2 a:{!r}, b:{!r}>".format(self.a, self.b)
+    return "<Tuple2 a:{!r}, b:{!r}>".format(self._a, self._b)
 
 class Other:
-  def __init__(self, a):
-    self.a = a
+  def __init__(self, _a):
+    self._a = _a
 
-  def get_a(self):
-    return self.a
+  @property
+  def a(self):
+    return self._a
 
   @staticmethod
   def decode(data):
@@ -135,12 +142,12 @@ class Other:
   def encode(self):
     data = dict()
 
-    if self.a is None:
+    if self._a is None:
       raise Exception("a: is a required field")
 
-    data["a"] = self.a
+    data["a"] = self._a
 
     return data
 
   def __repr__(self):
-    return "<Other a:{!r}>".format(self.a)
+    return "<Other a:{!r}>".format(self._a)

--- a/it/tuple/structures/default/python3/test.py
+++ b/it/tuple/structures/default/python3/test.py
@@ -1,13 +1,15 @@
 class Entry:
-  def __init__(self, tuple1, tuple2):
-    self.tuple1 = tuple1
-    self.tuple2 = tuple2
+  def __init__(self, _tuple1, _tuple2):
+    self._tuple1 = _tuple1
+    self._tuple2 = _tuple2
 
-  def get_tuple1(self):
-    return self.tuple1
+  @property
+  def tuple1(self):
+    return self._tuple1
 
-  def get_tuple2(self):
-    return self.tuple2
+  @property
+  def tuple2(self):
+    return self._tuple2
 
   @staticmethod
   def decode(data):
@@ -32,27 +34,29 @@ class Entry:
   def encode(self):
     data = dict()
 
-    if self.tuple1 is not None:
-      data["tuple1"] = self.tuple1.encode()
+    if self._tuple1 is not None:
+      data["tuple1"] = self._tuple1.encode()
 
-    if self.tuple2 is not None:
-      data["tuple2"] = self.tuple2.encode()
+    if self._tuple2 is not None:
+      data["tuple2"] = self._tuple2.encode()
 
     return data
 
   def __repr__(self):
-    return "<Entry tuple1:{!r}, tuple2:{!r}>".format(self.tuple1, self.tuple2)
+    return "<Entry tuple1:{!r}, tuple2:{!r}>".format(self._tuple1, self._tuple2)
 
 class Tuple1:
-  def __init__(self, a, b):
-    self.a = a
-    self.b = b
+  def __init__(self, _a, _b):
+    self._a = _a
+    self._b = _b
 
-  def get_a(self):
-    return self.a
+  @property
+  def a(self):
+    return self._a
 
-  def get_b(self):
-    return self.b
+  @property
+  def b(self):
+    return self._b
 
   @staticmethod
   def decode(data):
@@ -69,27 +73,29 @@ class Tuple1:
     return Tuple1(f_a, f_b)
 
   def encode(self):
-    if self.a is None:
+    if self._a is None:
       raise Exception("a: is a required field")
 
-    if self.b is None:
+    if self._b is None:
       raise Exception("b: is a required field")
 
-    return (self.a, self.b)
+    return (self._a, self._b)
 
   def __repr__(self):
-    return "<Tuple1 a:{!r}, b:{!r}>".format(self.a, self.b)
+    return "<Tuple1 a:{!r}, b:{!r}>".format(self._a, self._b)
 
 class Tuple2:
-  def __init__(self, a, b):
-    self.a = a
-    self.b = b
+  def __init__(self, _a, _b):
+    self._a = _a
+    self._b = _b
 
-  def get_a(self):
-    return self.a
+  @property
+  def a(self):
+    return self._a
 
-  def get_b(self):
-    return self.b
+  @property
+  def b(self):
+    return self._b
 
   @staticmethod
   def decode(data):
@@ -105,23 +111,24 @@ class Tuple2:
     return Tuple2(f_a, f_b)
 
   def encode(self):
-    if self.a is None:
+    if self._a is None:
       raise Exception("a: is a required field")
 
-    if self.b is None:
+    if self._b is None:
       raise Exception("b: is a required field")
 
-    return (self.a, self.b.encode())
+    return (self._a, self._b.encode())
 
   def __repr__(self):
-    return "<Tuple2 a:{!r}, b:{!r}>".format(self.a, self.b)
+    return "<Tuple2 a:{!r}, b:{!r}>".format(self._a, self._b)
 
 class Other:
-  def __init__(self, a):
-    self.a = a
+  def __init__(self, _a):
+    self._a = _a
 
-  def get_a(self):
-    return self.a
+  @property
+  def a(self):
+    return self._a
 
   @staticmethod
   def decode(data):
@@ -135,12 +142,12 @@ class Other:
   def encode(self):
     data = dict()
 
-    if self.a is None:
+    if self._a is None:
       raise Exception("a: is a required field")
 
-    data["a"] = self.a
+    data["a"] = self._a
 
     return data
 
   def __repr__(self):
-    return "<Other a:{!r}>".format(self.a)
+    return "<Other a:{!r}>".format(self._a)

--- a/it/versions/structures/default/python/bar/v1.py
+++ b/it/versions/structures/default/python/bar/v1.py
@@ -1,9 +1,10 @@
 class Other:
-  def __init__(self, name):
-    self.name = name
+  def __init__(self, _name):
+    self._name = _name
 
-  def get_name(self):
-    return self.name
+  @property
+  def name(self):
+    return self._name
 
   @staticmethod
   def decode(data):
@@ -17,12 +18,12 @@ class Other:
   def encode(self):
     data = dict()
 
-    if self.name is None:
+    if self._name is None:
       raise Exception("name: is a required field")
 
-    data["name"] = self.name
+    data["name"] = self._name
 
     return data
 
   def __repr__(self):
-    return "<Other name:{!r}>".format(self.name)
+    return "<Other name:{!r}>".format(self._name)

--- a/it/versions/structures/default/python/bar/v2_0.py
+++ b/it/versions/structures/default/python/bar/v2_0.py
@@ -1,9 +1,10 @@
 class Other:
-  def __init__(self, name2):
-    self.name2 = name2
+  def __init__(self, _name2):
+    self._name2 = _name2
 
-  def get_name2(self):
-    return self.name2
+  @property
+  def name2(self):
+    return self._name2
 
   @staticmethod
   def decode(data):
@@ -17,12 +18,12 @@ class Other:
   def encode(self):
     data = dict()
 
-    if self.name2 is None:
+    if self._name2 is None:
       raise Exception("name2: is a required field")
 
-    data["name2"] = self.name2
+    data["name2"] = self._name2
 
     return data
 
   def __repr__(self):
-    return "<Other name2:{!r}>".format(self.name2)
+    return "<Other name2:{!r}>".format(self._name2)

--- a/it/versions/structures/default/python/bar/v2_1.py
+++ b/it/versions/structures/default/python/bar/v2_1.py
@@ -1,9 +1,10 @@
 class Other:
-  def __init__(self, name21):
-    self.name21 = name21
+  def __init__(self, _name21):
+    self._name21 = _name21
 
-  def get_name21(self):
-    return self.name21
+  @property
+  def name21(self):
+    return self._name21
 
   @staticmethod
   def decode(data):
@@ -17,12 +18,12 @@ class Other:
   def encode(self):
     data = dict()
 
-    if self.name21 is None:
+    if self._name21 is None:
       raise Exception("name21: is a required field")
 
-    data["name21"] = self.name21
+    data["name21"] = self._name21
 
     return data
 
   def __repr__(self):
-    return "<Other name21:{!r}>".format(self.name21)
+    return "<Other name21:{!r}>".format(self._name21)

--- a/it/versions/structures/default/python/foo/v4.py
+++ b/it/versions/structures/default/python/foo/v4.py
@@ -3,23 +3,27 @@ import bar.v2_0 as bar2
 import bar.v2_1 as bar21
 
 class Thing:
-  def __init__(self, name, other, other2, other21):
-    self.name = name
-    self.other = other
-    self.other2 = other2
-    self.other21 = other21
+  def __init__(self, _name, _other, _other2, _other21):
+    self._name = _name
+    self._other = _other
+    self._other2 = _other2
+    self._other21 = _other21
 
-  def get_name(self):
-    return self.name
+  @property
+  def name(self):
+    return self._name
 
-  def get_other(self):
-    return self.other
+  @property
+  def other(self):
+    return self._other
 
-  def get_other2(self):
-    return self.other2
+  @property
+  def other2(self):
+    return self._other2
 
-  def get_other21(self):
-    return self.other21
+  @property
+  def other21(self):
+    return self._other21
 
   @staticmethod
   def decode(data):
@@ -61,19 +65,19 @@ class Thing:
   def encode(self):
     data = dict()
 
-    if self.name is not None:
-      data["name"] = self.name
+    if self._name is not None:
+      data["name"] = self._name
 
-    if self.other is not None:
-      data["other"] = self.other.encode()
+    if self._other is not None:
+      data["other"] = self._other.encode()
 
-    if self.other2 is not None:
-      data["other2"] = self.other2.encode()
+    if self._other2 is not None:
+      data["other2"] = self._other2.encode()
 
-    if self.other21 is not None:
-      data["other21"] = self.other21.encode()
+    if self._other21 is not None:
+      data["other21"] = self._other21.encode()
 
     return data
 
   def __repr__(self):
-    return "<Thing name:{!r}, other:{!r}, other2:{!r}, other21:{!r}>".format(self.name, self.other, self.other2, self.other21)
+    return "<Thing name:{!r}, other:{!r}, other2:{!r}, other21:{!r}>".format(self._name, self._other, self._other2, self._other21)

--- a/it/versions/structures/default/python/test.py
+++ b/it/versions/structures/default/python/test.py
@@ -1,11 +1,12 @@
 import foo.v4 as foo
 
 class Entry:
-  def __init__(self, thing):
-    self.thing = thing
+  def __init__(self, _thing):
+    self._thing = _thing
 
-  def get_thing(self):
-    return self.thing
+  @property
+  def thing(self):
+    return self._thing
 
   @staticmethod
   def decode(data):
@@ -22,10 +23,10 @@ class Entry:
   def encode(self):
     data = dict()
 
-    if self.thing is not None:
-      data["thing"] = self.thing.encode()
+    if self._thing is not None:
+      data["thing"] = self._thing.encode()
 
     return data
 
   def __repr__(self):
-    return "<Entry thing:{!r}>".format(self.thing)
+    return "<Entry thing:{!r}>".format(self._thing)

--- a/it/versions/structures/default/python3/bar/v1.py
+++ b/it/versions/structures/default/python3/bar/v1.py
@@ -1,9 +1,10 @@
 class Other:
-  def __init__(self, name):
-    self.name = name
+  def __init__(self, _name):
+    self._name = _name
 
-  def get_name(self):
-    return self.name
+  @property
+  def name(self):
+    return self._name
 
   @staticmethod
   def decode(data):
@@ -17,12 +18,12 @@ class Other:
   def encode(self):
     data = dict()
 
-    if self.name is None:
+    if self._name is None:
       raise Exception("name: is a required field")
 
-    data["name"] = self.name
+    data["name"] = self._name
 
     return data
 
   def __repr__(self):
-    return "<Other name:{!r}>".format(self.name)
+    return "<Other name:{!r}>".format(self._name)

--- a/it/versions/structures/default/python3/bar/v2_0.py
+++ b/it/versions/structures/default/python3/bar/v2_0.py
@@ -1,9 +1,10 @@
 class Other:
-  def __init__(self, name2):
-    self.name2 = name2
+  def __init__(self, _name2):
+    self._name2 = _name2
 
-  def get_name2(self):
-    return self.name2
+  @property
+  def name2(self):
+    return self._name2
 
   @staticmethod
   def decode(data):
@@ -17,12 +18,12 @@ class Other:
   def encode(self):
     data = dict()
 
-    if self.name2 is None:
+    if self._name2 is None:
       raise Exception("name2: is a required field")
 
-    data["name2"] = self.name2
+    data["name2"] = self._name2
 
     return data
 
   def __repr__(self):
-    return "<Other name2:{!r}>".format(self.name2)
+    return "<Other name2:{!r}>".format(self._name2)

--- a/it/versions/structures/default/python3/bar/v2_1.py
+++ b/it/versions/structures/default/python3/bar/v2_1.py
@@ -1,9 +1,10 @@
 class Other:
-  def __init__(self, name21):
-    self.name21 = name21
+  def __init__(self, _name21):
+    self._name21 = _name21
 
-  def get_name21(self):
-    return self.name21
+  @property
+  def name21(self):
+    return self._name21
 
   @staticmethod
   def decode(data):
@@ -17,12 +18,12 @@ class Other:
   def encode(self):
     data = dict()
 
-    if self.name21 is None:
+    if self._name21 is None:
       raise Exception("name21: is a required field")
 
-    data["name21"] = self.name21
+    data["name21"] = self._name21
 
     return data
 
   def __repr__(self):
-    return "<Other name21:{!r}>".format(self.name21)
+    return "<Other name21:{!r}>".format(self._name21)

--- a/it/versions/structures/default/python3/foo/v4.py
+++ b/it/versions/structures/default/python3/foo/v4.py
@@ -3,23 +3,27 @@ import bar.v2_0 as bar2
 import bar.v2_1 as bar21
 
 class Thing:
-  def __init__(self, name, other, other2, other21):
-    self.name = name
-    self.other = other
-    self.other2 = other2
-    self.other21 = other21
+  def __init__(self, _name, _other, _other2, _other21):
+    self._name = _name
+    self._other = _other
+    self._other2 = _other2
+    self._other21 = _other21
 
-  def get_name(self):
-    return self.name
+  @property
+  def name(self):
+    return self._name
 
-  def get_other(self):
-    return self.other
+  @property
+  def other(self):
+    return self._other
 
-  def get_other2(self):
-    return self.other2
+  @property
+  def other2(self):
+    return self._other2
 
-  def get_other21(self):
-    return self.other21
+  @property
+  def other21(self):
+    return self._other21
 
   @staticmethod
   def decode(data):
@@ -61,19 +65,19 @@ class Thing:
   def encode(self):
     data = dict()
 
-    if self.name is not None:
-      data["name"] = self.name
+    if self._name is not None:
+      data["name"] = self._name
 
-    if self.other is not None:
-      data["other"] = self.other.encode()
+    if self._other is not None:
+      data["other"] = self._other.encode()
 
-    if self.other2 is not None:
-      data["other2"] = self.other2.encode()
+    if self._other2 is not None:
+      data["other2"] = self._other2.encode()
 
-    if self.other21 is not None:
-      data["other21"] = self.other21.encode()
+    if self._other21 is not None:
+      data["other21"] = self._other21.encode()
 
     return data
 
   def __repr__(self):
-    return "<Thing name:{!r}, other:{!r}, other2:{!r}, other21:{!r}>".format(self.name, self.other, self.other2, self.other21)
+    return "<Thing name:{!r}, other:{!r}, other2:{!r}, other21:{!r}>".format(self._name, self._other, self._other2, self._other21)

--- a/it/versions/structures/default/python3/test.py
+++ b/it/versions/structures/default/python3/test.py
@@ -1,11 +1,12 @@
 import foo.v4 as foo
 
 class Entry:
-  def __init__(self, thing):
-    self.thing = thing
+  def __init__(self, _thing):
+    self._thing = _thing
 
-  def get_thing(self):
-    return self.thing
+  @property
+  def thing(self):
+    return self._thing
 
   @staticmethod
   def decode(data):
@@ -22,10 +23,10 @@ class Entry:
   def encode(self):
     data = dict()
 
-    if self.thing is not None:
-      data["thing"] = self.thing.encode()
+    if self._thing is not None:
+      data["thing"] = self._thing.encode()
 
     return data
 
   def __repr__(self):
-    return "<Entry thing:{!r}>".format(self.thing)
+    return "<Entry thing:{!r}>".format(self._thing)

--- a/lib/backend-python/src/compiler.rs
+++ b/lib/backend-python/src/compiler.rs
@@ -180,7 +180,7 @@ impl<'el> Compiler<'el> {
         let mut args = Tokens::new();
 
         for (i, field) in fields.into_iter().enumerate() {
-            let n = Rc::new(format!("f_{}", field.safe_ident()));
+            let n = Rc::new(format!("f_{}", field.ident));
             let var = variable_fn(i, field);
 
             if field.is_optional() {
@@ -274,7 +274,8 @@ impl<'el> Compiler<'el> {
         for field in fields {
             let name = Rc::new(self.to_lower_snake.convert(field.ident.as_str()));
             let mut body = Tokens::new();
-            body.push(toks!("def get_", name, "(self):"));
+            body.push("@property");
+            body.push(toks!("def ", name, "(self):"));
 
             body.nested({
                 let mut t = Tokens::new();

--- a/lib/backend-python/src/flavored.rs
+++ b/lib/backend-python/src/flavored.rs
@@ -269,7 +269,20 @@ impl FlavorTranslator for PythonFlavorTranslator {
     type Source = CoreFlavor;
     type Target = PythonFlavor;
 
-    translator_defaults!(Self, field, endpoint, enum_type);
+    translator_defaults!(Self, endpoint, enum_type);
+
+    fn translate_field<T>(
+        &self,
+        translator: &T,
+        diag: &mut Diagnostics,
+        field: core::RpField<Self::Source>,
+    ) -> Result<core::RpField<Self::Target>>
+    where
+        T: Translator<Source = Self::Source, Target = Self::Target>,
+    {
+        let ident = format!("_{}", field.ident);
+        field.with_safe_ident(ident).translate(diag, translator)
+    }
 
     fn translate_number(&self, _: RpNumberType) -> Result<PythonType<'static>> {
         Ok(self.ty(PythonKind::Integer))

--- a/lib/backend-python/src/lib.rs
+++ b/lib/backend-python/src/lib.rs
@@ -194,7 +194,8 @@ fn compile(handle: &Handle, session: Session<CoreFlavor>, manifest: Manifest) ->
         RpField::new(
             "ordinal",
             flavored::PythonType::new(helper, flavored::PythonKind::String),
-        ),
+        )
+        .with_safe_ident("_ordinal"),
         Span::empty(),
     );
 


### PR DESCRIPTION
Suggested by @bbqsrc as a more idiomatic way to have getters.

This creates some awkwardness in the RpField data structure, which probably means we should replace it with a python-specific variant. `safe_ident` is primarily supposed to be keyword-free identifiers.