### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/lib/semver/version.rs
+++ b/lib/semver/version.rs
@@ -807,7 +807,7 @@ mod tests {
             ("1.2.3-r100", "1.2.3-R2"),
         ];
 
-        for (i, &SemverTest(left, right, loose)) in input.into_iter().enumerate() {
+        for (i, &SemverTest(left, right, loose)) in input.iter().enumerate() {
             // NOTE: we don't support loose parsing.
             if loose {
                 continue;


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.